### PR TITLE
Associer plusieurs commande sur une facure

### DIFF
--- a/ajax/billactions.php
+++ b/ajax/billactions.php
@@ -42,9 +42,10 @@ if (isset($_POST["action"])) {
       case "bill":
          echo "&nbsp;<input type='hidden' name='plugin_order_orders_id' "
             . " value='" . $_POST["plugin_order_orders_id"] . "'>";
-         PluginOrderBill::Dropdown(array(
+          echo "<input type='hidden' name='plugin_order_bills_id' value='" . $_POST["plugin_order_bills_id"] . "'>";
+         /*PluginOrderBill::Dropdown(array(
             'condition' => "`plugin_order_orders_id`='" . $_POST['plugin_order_orders_id'] . "'",
-         ));
+         ));*/
          break;
    }
 

--- a/front/bill.form.php
+++ b/front/bill.form.php
@@ -1,85 +1,90 @@
 <?php
+
 /*
- LICENSE
+  LICENSE
 
- This file is part of the order plugin.
+  This file is part of the order plugin.
 
- Order plugin is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
+  Order plugin is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
- Order plugin is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+  Order plugin is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with GLPI; along with Order. If not, see <http://www.gnu.org/licenses/>.
- --------------------------------------------------------------------------
- @package   order
- @author    the order plugin team
- @copyright Copyright (c) 2010-2015 Order plugin team
- @license   GPLv2+
-            http://www.gnu.org/licenses/gpl.txt
- @link      https://forge.indepnet.net/projects/order
- @link      http://www.glpi-project.org/
- @since     2009
- ---------------------------------------------------------------------- */
+  You should have received a copy of the GNU General Public License
+  along with GLPI; along with Order. If not, see <http://www.gnu.org/licenses/>.
+  --------------------------------------------------------------------------
+  @package   order
+  @author    the order plugin team
+  @copyright Copyright (c) 2010-2015 Order plugin team
+  @license   GPLv2+
+  http://www.gnu.org/licenses/gpl.txt
+  @link      https://forge.indepnet.net/projects/order
+  @link      http://www.glpi-project.org/
+  @since     2009
+  ---------------------------------------------------------------------- */
 
 include ("../../../inc/includes.php");
 
 $bill = new PluginOrderBill();
 
 if (isset($_REQUEST['add'])) {
-   $bill->add($_REQUEST);
-   Html::back();
+    $bill->add($_REQUEST);
+    Html::back();
 }
 
 if (isset($_REQUEST['update'])) {
-   $bill->update($_REQUEST);
-   Html::back();
+    $bill->update($_REQUEST);
+    Html::back();
 }
 
 if (isset($_REQUEST['purge'])) {
-   $bill->delete($_REQUEST);
-   $bill->redirectToList();
+    $bill->delete($_REQUEST);
+    $bill->redirectToList();
 }
 
 if (isset($_POST['action'])) {
-   // Retrieve configuration for generate assets feature
+    // Retrieve configuration for generate assets feature
+    if ($_POST['action'] == 'Ajouter') {
+        PluginOrderOrder::add_order_to_bill($_POST['order_to_add'], $_POST['plugin_order_bills_id']);
+    } else {
+        $order_item = new PluginOrderOrder_Item();
+        switch ($_POST['chooseAction']) {
+            case 'bill':
+            case 'state':
+                if (isset($_POST["item"])) {
+                    foreach ($_POST["item"] as $key => $val) {
+                        if ($val == 1) {
+                            $tmp = $_POST;
+                            $tmp['id'] = $key;
+                            $order_item->update($tmp);
 
-   $order_item = new PluginOrderOrder_Item();
-   switch ($_POST['chooseAction']) {
-      case 'bill':
-      case 'state':
-         if (isset ($_POST["item"])) {
-            foreach ($_POST["item"] as $key => $val) {
-               if ($val == 1) {
-                  $tmp       = $_POST;
-                  $tmp['id'] = $key;
-                  $order_item->update($tmp);
+                            // Update infocom
+                            $ic = new Infocom();
+                            $ic->getFromDBforDevice($order_item->fields['itemtype'], $order_item->fields['items_id']);
 
-                  // Update infocom
-                  $ic = new Infocom();
-                  $ic->getFromDBforDevice($order_item->fields['itemtype'], $order_item->fields['items_id']);
+                            $config = PluginOrderConfig::getConfig();
 
-                  $config = PluginOrderConfig::getConfig();
-                  if ($config->canAddBillDetails()) {
-                     if ($bill->getFromDB($_POST["plugin_order_bills_id"])) {
-                        $fields['id'] = $ic->fields['id'];
-                        $fields['bill'] = $bill->fields['number'];
-                        $fields['warranty_date'] = $bill->fields['billdate'];
-                     }
-                  }
-                  $ic->update($fields);
-               }
-            }
-         }
-         break;
-   }
-   PluginOrderOrder::updateBillState($order_item->fields['plugin_order_orders_id']);
-   Html::back();
+                            if ($bill->getFromDB($_POST["plugin_order_bills_id"])) {
+                                $fields['id'] = $ic->fields['id'];
+                                $fields['bill'] = $bill->fields['number'];
+                                $fields['warranty_date'] = $bill->fields['billdate'];
+                            }
+
+                            $ic->update($fields);
+                        }
+                    }
+                }
+                break;
+        }
+        PluginOrderOrder::updateBillState($order_item->fields['plugin_order_orders_id']);
+    }
+
+    Html::back();
 }
 $dropdown = new PluginOrderBill();
 
@@ -87,9 +92,9 @@ Session::checkRight("plugin_order_bill", READ);
 
 Html::header(PluginOrderBill::getTypeName(1), $_SERVER['PHP_SELF'], "management", "PluginOrderMenu", "bill");
 if (isset($_REQUEST['id'])) {
-   $bill->display($_REQUEST);
+    $bill->display($_REQUEST);
 } else {
-   $bill->show();
+    $bill->show();
 }
 
 Html::footer();

--- a/hook.php
+++ b/hook.php
@@ -46,7 +46,7 @@ function plugin_order_install() {
    $classes = array('PluginOrderConfig', 'PluginOrderBillState', 'PluginOrderBillType',
                     'PluginOrderOrderState', 'PluginOrderOrder','PluginOrderOrder_Item',
                     'PluginOrderReference', 'PluginOrderDeliveryState',
-                    'PluginOrderNotificationTargetOrder',
+                    'PluginOrderNotificationTargetOrder','PluginOrderBillOrder',
                     'PluginOrderOrder_Supplier', 'PluginOrderBill', 'PluginOrderOrderPayment',
                     'PluginOrderOrderType', 'PluginOrderOther', 'PluginOrderOtherType',
                     'PluginOrderPreference', 'PluginOrderProfile', 'PluginOrderReference_Supplier',
@@ -81,7 +81,7 @@ function plugin_order_uninstall() {
    $classes = array('PluginOrderConfig', 'PluginOrderBill', 'PluginOrderBillState',
                     'PluginOrderBillType', 'PluginOrderOrderState', 'PluginOrderOrder',
                     'PluginOrderOrder_Item', 'PluginOrderReference', 'PluginOrderDeliveryState',
-                    'PluginOrderNotificationTargetOrder',
+                    'PluginOrderNotificationTargetOrder','PluginOrderBillOrder',
                     'PluginOrderOrder_Supplier', 'PluginOrderOrderPayment','PluginOrderOrderTax',
                     'PluginOrderOrderType', 'PluginOrderOther', 'PluginOrderOtherType',
                     'PluginOrderPreference', 'PluginOrderProfile', 'PluginOrderReference_Supplier',
@@ -225,47 +225,6 @@ function plugin_order_addLeftJoin($type,$ref_table,$new_table,$linkfield,
    }
 
    return "";
-}
-
-function plugin_order_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype) {
-   global $ORDER_TYPES;
-
-   $out = " AND ";
-
-   if ($ID == 6) {
-      Toolbox::logDebug($link, $nott, $itemtype, $ID, $val, $searchtype, $out);
-      switch ($searchtype) {
-         case 'contains':
-            $comparison = "`name` " . Search::makeTextSearch($val, $nott);
-      }
-
-      $assetTypesType = array();
-      foreach ($ORDER_TYPES as $assetType) {
-         if ($itemtype == 'PluginOrderReference') {
-            $table = strtolower("glpi_" . $assetType::getType()."types");
-            if (TableExists($table)) {
-               $assetTypestype[] = "SELECT `id`
-                                    FROM `$table`
-                                    WHERE `itemtype`='$assetType'
-                                       AND `types_id`=`$table`.`id`
-                                       AND $comparison";
-            }
-         }
-      }
-      if (count($assetTypestype)) {
-         $out= "$link `types_id` IN (" . implode(" UNION ", $assetTypestype) . ")";
-      }
-   }
-   if ($ID == 3) {
-      $table = $itemtype::getTable();
-      if ($nott) {
-         $out = "$link `itemtype`<>'$val'";
-      } else {
-         $out = "$link `$table`.`itemtype`='$val'";
-      }
-   }
-
-   return $out;
 }
 
 /* display custom fields in the search */

--- a/inc/bill.class.php
+++ b/inc/bill.class.php
@@ -422,8 +422,7 @@ $random=$rand + $order->getID();
 
             $req_orders_add = "SELECT id, concat(name,' ', order_date) from glpi_plugin_order_orders " .
                     "where id in ( SELECT plugin_order_orders_id FROM `glpi_plugin_order_orders_items` " .
-                    "where plugin_order_bills_id=0 ".
-                    "OR plugin_order_bills_id='" . $bill_id . "' GROUP BY plugin_order_orders_id) " .
+                    "where plugin_order_bills_id=0 GROUP BY plugin_order_orders_id) " .
                     "AND id not in (SELECT glpi_plugin_order_orders_id FROM glpi_plugin_order_billsorder) " .
                     "AND suppliers_id='" . $bill_supplier . "'";
             $result_req_orders_add = $DB->query($req_orders_add);

--- a/inc/bill.class.php
+++ b/inc/bill.class.php
@@ -213,7 +213,7 @@ class PluginOrderBill extends CommonDropdown {
                 if ($data['itemtype']::canView()) {
                     
                     $order = new PluginOrderOrder();
-                    $order->getFromDB($data["id"]);
+                    $order->getFromDB($data["plugin_order_orders_id"]);
                     echo "<tr class='tab_bg_1'>";
 
                     $ID = "";
@@ -392,10 +392,7 @@ $random=$rand + $order->getID();
             echo "</table>";
 
             echo "</div>";
-        } else {
-            echo "<div class='center'><table class='tab_cadre_fixe'>";
-            echo "<tr><th>" . __("No item to take delivery of", "order") . "</th></tr></table></div>";
-        }
+        
 
         if ($canedit) {
             echo "<div class='center'>";
@@ -418,7 +415,16 @@ $random=$rand + $order->getID();
             echo "</td></tr>";
 
 
-            echo "<tr><td>";
+            
+            
+        }
+        } else {
+            echo "<div class='center'><table class='tab_cadre_fixe'>";
+            echo "<tr><th>" . __("No item to take delivery of", "order") . "</th></tr></table></div>";
+        }
+        
+        echo "<div class='center'><table class='tab_cadre_fixe'>";
+echo "<tr><td>";
 
             $req_orders_add = "SELECT id, concat(name,' ', order_date) from glpi_plugin_order_orders " .
                     "where id in ( SELECT plugin_order_orders_id FROM `glpi_plugin_order_orders_items` " .
@@ -442,8 +448,6 @@ $random=$rand + $order->getID();
                 echo "</td></tr></table>";
                 echo "</div>";
             }
-        }
-
         Html::closeForm();
 
 

--- a/inc/bill.class.php
+++ b/inc/bill.class.php
@@ -1,413 +1,464 @@
 <?php
+
 /*
- LICENSE
+  LICENSE
 
- This file is part of the order plugin.
+  This file is part of the order plugin.
 
- Order plugin is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
+  Order plugin is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
- Order plugin is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+  Order plugin is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with GLPI; along with Order. If not, see <http://www.gnu.org/licenses/>.
- --------------------------------------------------------------------------
- @package   order
- @author    the order plugin team
- @copyright Copyright (c) 2010-2015 Order plugin team
- @license   GPLv2+
-            http://www.gnu.org/licenses/gpl.txt
- @link      https://forge.indepnet.net/projects/order
- @link      http://www.glpi-project.org/
- @since     2009
- ---------------------------------------------------------------------- */
+  You should have received a copy of the GNU General Public License
+  along with GLPI; along with Order. If not, see <http://www.gnu.org/licenses/>.
+  --------------------------------------------------------------------------
+  @package   order
+  @author    the order plugin team
+  @copyright Copyright (c) 2010-2015 Order plugin team
+  @license   GPLv2+
+  http://www.gnu.org/licenses/gpl.txt
+  @link      https://forge.indepnet.net/projects/order
+  @link      http://www.glpi-project.org/
+  @since     2009
+  ---------------------------------------------------------------------- */
 
-if (!defined('GLPI_ROOT')){
-   die("Sorry. You can't access directly to this file");
+if (!defined('GLPI_ROOT')) {
+    die("Sorry. You can't access directly to this file");
 }
 
-class PluginOrderBill extends CommonDropdown
-{
-   public static $rightname  = 'plugin_order_bill';
-   public $dohistory         = true;
-   public $first_level_menu  = "plugins";
-   public $second_level_menu = "order";
+class PluginOrderBill extends CommonDropdown {
 
-   public static function getTypeName($nb = 0) {
-      return __("Bill", "order");
-   }
+    public static $rightname = 'plugin_order_bill';
+    public $dohistory = true;
+    public $first_level_menu = "plugins";
+    public $second_level_menu = "order";
 
-   public function post_getEmpty() {
-      $this->fields['value'] = 0;
-   }
+    public static function getTypeName($nb = 0) {
+        return __("Bill", "order");
+    }
 
-   public function prepareInputForAdd($input) {
-      if (!isset ($input["number"]) || $input["number"] == '') {
-         Session::addMessageAfterRedirect(__("A bill number is mandatory", "order"), false, ERROR);
-         return array ();
-      }
+    public function post_getEmpty() {
+        $this->fields['value'] = 0;
+    }
 
-      return $input;
-   }
+    public function prepareInputForAdd($input) {
+        if (!isset($input["number"]) || $input["number"] == '') {
+            Session::addMessageAfterRedirect(__("A bill number is mandatory", "order"), false, ERROR);
+            return array();
+        }
 
-   public function getAdditionalFields() {
-      //$this->showTabs(); //hack
-      return array(array('name'  =>'suppliers_id',
-                         'label' => __("Supplier"),
-                         'type'  => 'dropdownValue'),
-                   array('name'  => 'value',
-                         'label' => __("Value"),
-                         'type'  => 'text'),
-                   array('name'  => 'number',
-                         'label' => _x("phone", "Number")." <span class='red'>*</span>",
-                         'type'  => 'text',
-                         'mandatory' => true),
-                   array('name'  => 'billdate',
-                         'label' => __("Date"),
-                         'type'  => 'date'),
-                   array('name'  => 'plugin_order_billtypes_id',
-                         'label' => __("Type"),
-                         'type'  => 'dropdownValue'),
-                   array('name'  => 'plugin_order_billstates_id',
-                         'label' => __("Status"),
-                         'type'  => 'dropdownValue'),
-                   array('name'  => 'plugin_order_orders_id',
-                         'label' => __("Order", "order"),
-                         'type'  => 'dropdownValue'),
-                   array('name'  => 'users_id_validation',
-                         'label' => __("Approver"),
-                         'type'  => 'UserDropdown'),
-                   array('name'  => 'validationdate',
-                         'label' => __("Approval date"),
-                         'type'  => 'date'));
-   }
+        return $input;
+    }
 
-   public function defineTabs($options = array()) {
-      $ong = array();
-      $this->addDefaultFormTab($ong);
-      $this->addStandardTab(__CLASS__,$ong,$options);
-      $this->addStandardTab('Document_Item',$ong,$options);
-      $this->addStandardTab('Note',$ong,$options);
-      $this->addStandardTab('Log',$ong,$options);
+    public function getAdditionalFields() {
+        //$this->showTabs(); //hack
+        return array(array('name' => 'suppliers_id',
+                'label' => __("Supplier"),
+                'type' => 'dropdownValue'),
+            array('name' => 'value',
+                'label' => __("Value"),
+                'type' => 'text'),
+            array('name' => 'number',
+                'label' => _x("phone", "Number") . " <span class='red'>*</span>",
+                'type' => 'text',
+                'mandatory' => true),
+            array('name' => 'billdate',
+                'label' => __("Date"),
+                'type' => 'date'),
+            array('name' => 'plugin_order_billtypes_id',
+                'label' => __("Type"),
+                'type' => 'dropdownValue'),
+            array('name' => 'plugin_order_billstates_id',
+                'label' => __("Status"),
+                'type' => 'dropdownValue'),
+            array('name' => 'users_id_validation',
+                'label' => __("Approver"),
+                'type' => 'UserDropdown'),
+            array('name' => 'validationdate',
+                'label' => __("Approval date"),
+                'type' => 'date'));
+    }
 
-      return $ong;
-   }
+    public function defineTabs($options = array()) {
+        $ong = array();
+        $this->addDefaultFormTab($ong);
+        $this->addStandardTab(__CLASS__, $ong, $options);
+        $this->addStandardTab('Document_Item', $ong, $options);
+        $this->addStandardTab('Note', $ong, $options);
+        $this->addStandardTab('Log', $ong, $options);
 
-   public function getSearchOptions() {
-      $tab = array();
+        return $ong;
+    }
 
-      $tab['common']            = __("Bill", "order");
+    public function getSearchOptions() {
+        $tab = array();
 
-      /* order_number */
-      $tab[1]['table']          = $this->getTable();
-      $tab[1]['field']          = 'number';
-      $tab[1]['name']           = _x("phone", "Number");
-      $tab[1]['datatype']       = 'itemlink';
+        $tab['common'] = __("Bill", "order");
 
-      $tab[2]['table']          = $this->getTable();
-      $tab[2]['field']          = 'billdate';
-      $tab[2]['name']           = __("Date");
-      $tab[2]['datatype']       = 'datetime';
+        /* order_number */
+        $tab[1]['table'] = $this->getTable();
+        $tab[1]['field'] = 'number';
+        $tab[1]['name'] = _x("phone", "Number");
+        $tab[1]['datatype'] = 'itemlink';
 
-      $tab[3]['table']          = $this->getTable();
-      $tab[3]['field']          = 'validationdate';
-      $tab[3]['name']           = __("Approval date");
-      $tab[3]['datatype']       = 'datetime';
+        $tab[2]['table'] = $this->getTable();
+        $tab[2]['field'] = 'billdate';
+        $tab[2]['name'] = __("Date");
+        $tab[2]['datatype'] = 'datetime';
 
-      $tab[4]['table']          = getTableForItemType('User');
-      $tab[4]['field']          = 'name';
-      $tab[4]['linkfield']      = 'users_id_validation';
-      $tab[4]['name']           = __("Approver");
+        $tab[3]['table'] = $this->getTable();
+        $tab[3]['field'] = 'validationdate';
+        $tab[3]['name'] = __("Approval date");
+        $tab[3]['datatype'] = 'datetime';
 
-      $tab[5]['table']          = getTableForItemType('PluginOrderBillType');
-      $tab[5]['field']          = 'name';
-      $tab[5]['name']           = __("Type");
+        $tab[4]['table'] = getTableForItemType('User');
+        $tab[4]['field'] = 'name';
+        $tab[4]['linkfield'] = 'users_id_validation';
+        $tab[4]['name'] = __("Approver");
 
-      $tab[6]['table']          = getTableForItemType('PluginOrderBillState');
-      $tab[6]['field']          = 'name';
-      $tab[6]['name']           = __("Status");
+        $tab[5]['table'] = getTableForItemType('PluginOrderBillType');
+        $tab[5]['field'] = 'name';
+        $tab[5]['name'] = __("Type");
 
-      $tab[7]['table']          = getTableForItemType('Supplier');
-      $tab[7]['field']          = 'name';
-      $tab[7]['name']           = __("Supplier");
-      $tab[7]['datatype']       = 'itemlink';
-      $tab[7]['itemlink_type']  = 'Supplier';
+        $tab[6]['table'] = getTableForItemType('PluginOrderBillState');
+        $tab[6]['field'] = 'name';
+        $tab[6]['name'] = __("Status");
 
-      $tab[8]['table']          = getTableForItemType('PluginOrderOrder');
-      $tab[8]['field']          = 'name';
-      $tab[8]['name']           = __("Order", "order");
-      $tab[8]['datatype']       = 'itemlink';
-      $tab[8]['itemlink_type']  = 'PluginOrderOrder';
+        $tab[7]['table'] = getTableForItemType('Supplier');
+        $tab[7]['field'] = 'name';
+        $tab[7]['name'] = __("Supplier");
+        $tab[7]['datatype'] = 'itemlink';
+        $tab[7]['itemlink_type'] = 'Supplier';
 
-      $tab[9]['table']          = $this->getTable();
-      $tab[9]['field']          = 'name';
-      $tab[9]['name']           = __("Name");
-      $tab[9]['datatype']       = 'itemlink';
 
-      /* comments */
-      $tab[16]['table']         = $this->getTable();
-      $tab[16]['field']         = 'comment';
-      $tab[16]['name']          = __("Description");
-      $tab[16]['datatype']      = 'text';
 
-      /* ID */
-      $tab[30]['table']         = $this->getTable();
-      $tab[30]['field']         = 'id';
-      $tab[30]['name']          = __("ID");
+        $tab[9]['table'] = $this->getTable();
+        $tab[9]['field'] = 'name';
+        $tab[9]['name'] = __("Name");
+        $tab[9]['datatype'] = 'itemlink';
 
-      /* entity */
-      $tab[80]['table']         = 'glpi_entities';
-      $tab[80]['field']         = 'completename';
-      $tab[80]['name']          = __("Entity");
+        /* comments */
+        $tab[16]['table'] = $this->getTable();
+        $tab[16]['field'] = 'comment';
+        $tab[16]['name'] = __("Description");
+        $tab[16]['datatype'] = 'text';
 
-      $tab[86]['table']         = $this->getTable();
-      $tab[86]['field']         = 'is_recursive';
-      $tab[86]['name']          = __("Child entities");
-      $tab[86]['datatype']      = 'bool';
-      $tab[86]['massiveaction'] = false;
+        /* ID */
+        $tab[30]['table'] = $this->getTable();
+        $tab[30]['field'] = 'id';
+        $tab[30]['name'] = __("ID");
 
-      return $tab;
-   }
+        /* entity */
+        $tab[80]['table'] = 'glpi_entities';
+        $tab[80]['field'] = 'completename';
+        $tab[80]['name'] = __("Entity");
 
-   public static function showItems(PluginOrderBill $bill) {
-      global $DB;
+        $tab[86]['table'] = $this->getTable();
+        $tab[86]['field'] = 'is_recursive';
+        $tab[86]['name'] = __("Child entities");
+        $tab[86]['datatype'] = 'bool';
+        $tab[86]['massiveaction'] = false;
 
-      echo "<div class='spaced'><table class='tab_cadre_fixehov'>";
-      echo "<tr><th>";
-      Html::printPagerForm();
-      echo "</th><th colspan='5'>";
-      echo _n("Item", "Items", 2);
-      echo "</th></tr>";
+        return $tab;
+    }
 
-      $bills_id = $bill->getID();
-      $table = getTableForItemType("PluginOrderOrder_Item");
-      
-      $query  = "SELECT * FROM `" . $table . "`";
-      $query .= " WHERE `plugin_order_bills_id` = '$bills_id'";
-      $query .= getEntitiesRestrictRequest(" AND", $table, "entities_id", $bill->getEntityID(), true);
-      $query .= "GROUP BY `itemtype`";
-      
-      $result = $DB->query($query);
-      $number = $DB->numrows($result);
+    public static function showItems(PluginOrderBill $bill) {
+        global $DB;
 
-      if (!$number) {
-         echo "</th><td>";
-         echo _n("Item", "Items", 2);
-         echo "</td></tr>";
-      } else {
-         echo "<tr>";
-         echo "<th>" . __("Type") . "</th>";
-         echo "<th>" . __("Entity") . "</th>";
-         echo "<th>" . __("Reference") . "</th>";
-         echo "<th>" . __("Status") . "</th>";
-         echo "</tr>";
+        echo "<div class='spaced'><table class='tab_cadre_fixehov'>";
+        echo "<tr><th>";
+        Html::printPagerForm();
+        echo "</th><th colspan='5'>";
+        echo _n("Item", "Items", 2);
+        echo "</th></tr>";
 
-         $old_itemtype = '';
-         $num          = 0;
+        $bills_id = $bill->getID();
+        $table = getTableForItemType("PluginOrderOrder_Item");
 
-         while ($data = $DB->fetch_array($result)) {
-            if (!class_exists($data['itemtype'])) {
-               continue;
-            }
-            $item = new $data['itemtype']();
-            if ($data['itemtype']::canView()) {
-               echo "<tr class='tab_bg_1'>";
+        $query = "SELECT * FROM `" . $table . "`";
+        $query .= " WHERE `plugin_order_bills_id` = '$bills_id'";
+        $query .= getEntitiesRestrictRequest(" AND", $table, "entities_id", $bill->getEntityID(), true);
+        
 
-               $ID = "";
-               if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {
-                    $ID = " (" . $data["id"] . ")";
-               }
-               $name = NOT_AVAILABLE;
-               if ($item->getFromDB($data["id"])) {
-                    $name = $item->getLink();
-               }
+        $result = $DB->query($query);
+        $number = $DB->numrows($result);
 
-               echo "<td class='center top'>" . $item->getTypeName() . "</td>";
-               echo "<td class='center top'>";
-               echo Dropdown::getDropdownName('glpi_entities', $item->getEntityID())."</td>";
-
-               $reference = new PluginOrderReference();
-               $reference->getFromDB($data["plugin_order_references_id"]);
-               echo "<td class='center'>";
-               if (PluginOrderReference::canView()) {
-                  echo $reference->getLink();
-               } else {
-                  echo $reference->getName(true);
-               }
-               echo "</td>";
-               echo "<td class='center'>";
-               Dropdown::getDropdownName("glpi_plugin_order_deliverystates",
-                                            $data["plugin_order_deliverystates_id"]);
-               echo "</td>";
-               echo "</tr>";
-            }
-         }
-      }
-      echo "</table></div>";
-   }
-
-   public static function showOrdersItems(PluginOrderBill $bill) {
-      global $DB, $CFG_GLPI;
-
-      $reference = new PluginOrderReference();
-      $order     = new PluginOrderOrder();
-      $order->getFromDB($bill->fields['plugin_order_orders_id']);
-
-      //Can write orders, and order is not already paid
-      $canedit = $order->can($order->getID(), UPDATE)
-                   && !$order->isPaid() && !$order->isCanceled();
-
-      $query_ref = "SELECT `glpi_plugin_order_orders_items`.`id` AS IDD, " .
-                     "`glpi_plugin_order_orders_items`.`plugin_order_references_id` AS id, " .
-                     "`glpi_plugin_order_references`.`name`, " .
-                     "`glpi_plugin_order_references`.`itemtype`, " .
-                     "`glpi_plugin_order_references`.`manufacturers_id` " .
-                   "FROM `glpi_plugin_order_orders_items`, `glpi_plugin_order_references` " .
-                   "WHERE `plugin_order_orders_id` = '".$order->getID()."' " .
-                     "AND `glpi_plugin_order_orders_items`.`plugin_order_references_id` = `glpi_plugin_order_references`.`id` " .
-                  "GROUP BY `glpi_plugin_order_orders_items`.`plugin_order_references_id` " .
-                  "ORDER BY `glpi_plugin_order_references`.`name`";
-      $result_ref = $DB->query($query_ref);
-
-      while ($data_ref = $DB->fetch_array($result_ref)) {
-         echo "<div class='center'><table class='tab_cadre_fixe'>";
-         if (!$DB->numrows($result_ref)) {
-            echo "<tr><th>" . __("No item to take delivery of", "order") . "</th></tr></table></div>";
-
-         } else {
-            $order_item = new PluginOrderOrder_Item();
-
-            $rand     = mt_rand();
-            $itemtype = $data_ref["itemtype"];
-            $item     = new $itemtype();
-            echo "<tr><th><ul><li>";
-            echo "<a href=\"javascript:showHideDiv('generation$rand','generation_img$rand', '"
-               . $CFG_GLPI['root_doc'] . "/pics/plus.png','" . $CFG_GLPI['root_doc'] . "/pics/moins.png');\">";
-            echo "<img alt='' name='generation_img$rand' src=\"" . $CFG_GLPI['root_doc'] . "/pics/plus.png\">";
-            echo "</a>";
-            echo "</li></ul></th>";
+        if (!$number) {
+            echo "</th><td>";
+            echo _n("Item", "Items", 2);
+            echo "</td></tr>";
+        } else {
+            echo "<tr>";
             echo "<th>" . __("Type") . "</th>";
-            echo "<th>" . __("Manufacturer") . "</th>";
-            echo "<th>" . __("Product reference", "order") . "</th>";
-            echo "</tr>";
-
-            echo "<tr class='tab_bg_1 center'>";
-            echo "<td></td>";
-            echo "<td align='center'>" . $item->getTypeName() . "</td>";
-
-            //Entity
-            echo "<td align='center'>";
-            echo Dropdown::getDropdownName('glpi_entities', $order->getEntityID());
-            echo "</td>";
-            echo "<td>" . $reference->getReceptionReferenceLink($data_ref) . "</td>";
-            echo "</tr></table>";
-
-            echo "<div class='center' id='generation$rand' style='display:none'>";
-            echo "<form method='post' name='bills_form$rand' id='bills_form$rand'
-                     action='" . Toolbox::getItemTypeFormURL('PluginOrderBill') . "'>";
-
-            echo "<input type='hidden' name='plugin_order_orders_id' value='" . $order->getID() . "'>";
-
-            echo "<table class='tab_cadre_fixe'>";
-
-            echo "<th></th>";
+            echo "<th>Date de commande</th>";
+            echo "<th>Commande</th>";
             echo "<th>" . __("Reference") . "</th>";
-            echo "<th>" . __("Type") . "</th>";
-            echo "<th>" . __("Model") . "</th>";
-            echo "<th>" . __("Bill", "order") . "</th>";
-            echo "<th>" . __("Bill status", "order") . "</th>";
+            echo "<th>" . __("Status") . "</th>";
             echo "</tr>";
 
-            $results = $order_item->queryBills($order->getID(), $data_ref['id']);
-            while ($data = $DB->fetch_array($results)) {
-               echo "<tr class='tab_bg_1'>";
-               if ($canedit){
-                  echo "<td width='10'>";
-                  $sel = "";
-                  if (isset($_GET["select"]) && $_GET["select"] == "all") {
-                     $sel = "checked";
-                  }
-                  echo "<input type='checkbox' name='item[".$data["IDD"]."]' value='1' $sel>";
-                  echo "<input type='hidden' name='plugin_order_orders_id' value='" .
-                      $order->getID() . "'>";
-                  echo "</td>";
-               }
+            $old_itemtype = '';
+            $num = 0;
 
-               //Reference
-               echo "<td align='center'>";
-               echo $reference->getReceptionReferenceLink($data);
-               echo "</td>";
+            while ($data = $DB->fetch_array($result)) {
+                if (!class_exists($data['itemtype'])) {
+                    continue;
+                }
+                $item = new $data['itemtype']();
+                if ($data['itemtype']::canView()) {
+                    
+                    $order = new PluginOrderOrder();
+                    $order->getFromDB($data["id"]);
+                    echo "<tr class='tab_bg_1'>";
 
-               //Type
-               echo "<td align='center'>";
-               if (file_exists($CFG_GLPI['root_doc']."/inc/".strtolower($data["itemtype"])."type.class.php")) {
-                  echo Dropdown::getDropdownName(getTableForItemType($data["itemtype"]."Type"),
-                                                                     $data["types_id"]);
-               }
-               echo "</td>";
+                    $ID = "";
+                    if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {
+                        $ID = " (" . $data["id"] . ")";
+                    }
+                    $name = NOT_AVAILABLE;
+                    if ($item->getFromDB($data["id"])) {
+                        $name = $item->getLink();
+                    }
 
-               //Model
-               echo "<td align='center'>";
-               if (file_exists($CFG_GLPI['root_doc']."/inc/".strtolower($data["itemtype"])."model.class.php")) {
-                  echo Dropdown::getDropdownName(getTableForItemType($data["itemtype"]."Model"),
-                                                 $data["models_id"]);
-               }
-               $bill = new PluginOrderBill();
-               echo "<td align='center'>";
-               if ($data["plugin_order_bills_id"] > 0) {
-                  if ($bill->can($data['plugin_order_bills_id'], READ)) {
-                     echo "<a href='".$bill->getLinkURL()."'>".$bill->getName(true)."</a>";
-                  } else {
-                     echo $bill->getName();
-                  }
-               }
-               echo "</td>";
-               echo "<td align='center'>";
-               echo Dropdown::getDropdownName(getTableForItemType('PluginOrderBillState'),
-                                                                  $data['plugin_order_billstates_id']);
-               echo "</td>";
-               echo "</tr>";
+                    echo "<td class='center top'>" . $item->getTypeName() . "</td>";
+                    echo "<td class='center top'>";
+                    echo $order->fields["order_date"]."</td>";
+                    echo "<td class='center top'>";
+                    echo "<a href='" . $order->getLinkURL() . "'>" . $order->getName(true) . "</a></td>";
+
+                    $reference = new PluginOrderReference();
+                    $reference->getFromDB($data["plugin_order_references_id"]);
+                    echo "<td class='center'>";
+                    if (PluginOrderReference::canView()) {
+                        echo $reference->getLink();
+                    } else {
+                        echo $reference->getName(true);
+                    }
+                    echo "</td>";
+                    echo "<td class='center'>";
+                    Dropdown::getDropdownName("glpi_plugin_order_deliverystates", $data["plugin_order_deliverystates_id"]);
+                    echo "</td>";
+                    echo "</tr>";
+                }
             }
-         }
-         echo "</table>";
+        }
+        echo "</table></div>";
+    }
 
-         if ($canedit) {
+    public static function showOrdersItems(PluginOrderBill $bill) {
+        global $DB, $CFG_GLPI;
+        $bill_id = $bill->getID();
+        $bill_supplier = $bill->fields['suppliers_id'];
+
+        $reference = new PluginOrderReference();
+        $order = new PluginOrderOrder();
+        $req_orders = "SELECT `glpi_plugin_order_orders_id`" .
+                " FROM `glpi_plugin_order_billsorder`" .
+                " WHERE `glpi_plugin_order_billsorder`.`glpi_plugin_order_bills_id`='" . $bill->getID() . "'";
+        $orders = $DB->query($req_orders);
+        $rand = mt_rand();
+        echo "<form method='post' name='bills_form$rand' id='bills_form$rand'
+                     action='" . Toolbox::getItemTypeFormURL('PluginOrderBill') . "'>";
+        if ($DB->numrows($orders)) {
+            
+            echo "<div class='center'><table class='tab_cadre_fixe'>";
+            echo "<tr><th></th>";
+            echo "<th>" . __("Type") . "</th>";
+            echo "<th>" . __("Date") . "</th>";
+            echo "<th>Nom de la commande</th>";
+            echo "</tr>";
+            while ($order_id = $DB->fetch_array($orders)) {
+
+                //Can write orders, and order is not already paid
+                $order->getFromDB($order_id[0]);
+                $canedit = $order->can($order->getID(), UPDATE) && !$order->isPaid() && !$order->isCanceled();
+
+                $query_ref = "SELECT `glpi_plugin_order_orders_items`.`id` AS IDD, " .
+                        "`glpi_plugin_order_orders_items`.`plugin_order_references_id` AS id, " .
+                        "`glpi_plugin_order_references`.`name`, " .
+                        "`glpi_plugin_order_references`.`itemtype`, " .
+                        "`glpi_plugin_order_references`.`manufacturers_id` " .
+                        "FROM `glpi_plugin_order_orders_items`, `glpi_plugin_order_references` " .
+                        "WHERE `plugin_order_orders_id` = '" . $order->getID() . "' " .
+                        "AND `glpi_plugin_order_orders_items`.`plugin_order_references_id` = `glpi_plugin_order_references`.`id` " .
+                        "GROUP BY `glpi_plugin_order_orders_items`.`plugin_order_references_id` " .
+                        "ORDER BY `glpi_plugin_order_references`.`name`";
+                $result_ref = $DB->query($query_ref);
+                if (!$DB->numrows($result_ref)) {
+                    echo "<tr><th>" . __("No item to take delivery of", "order") . "</th></tr></table></div>";
+                } else {
+
+                    while ($data_ref = $DB->fetch_array($result_ref)) {
+
+
+
+                        $order_item = new PluginOrderOrder_Item();
+
+
+                        $itemtype = $data_ref["itemtype"];
+                        $item = new $itemtype();
+$random=$rand + $order->getID();
+
+                        echo "<tr class='tab_bg_1 center'>";
+                        echo "<td><ul><li>";
+                        echo "<a href=\"javascript:showHideDiv('generation$random','generation_img$random', '"
+                        . $CFG_GLPI['root_doc'] . "/pics/plus.png','" . $CFG_GLPI['root_doc'] . "/pics/moins.png');\">";
+                        echo "<img alt='' name='generation_img$random' src=\"" . $CFG_GLPI['root_doc'] . "/pics/plus.png\">";
+                        echo "</a>";
+                        echo "</li></ul></td>";
+                        echo "<td align='center'>" . $item->getTypeName() . "</td>";
+
+                        //Entity
+                        echo "<td align='center'>";
+                        echo $order->fields['order_date'];
+                        echo "</td>";
+                        echo "<td><a href='" . $order->getLinkURL() . "'>" . $order->getName(true) . "</a></td>";
+                        echo "</tr>";
+                        echo "<tr><td></td>";
+                        echo "<td colspan='3'>";
+                        echo "<div class='center' id='generation$random' style='display:none'>";
+
+
+                        echo "<input type='hidden' name='plugin_order_orders_id' value='" . $order->getID() . "'>";
+
+                        echo "<table class='tab_cadre_fixe'>";
+
+                        echo "<th></th>";
+                        echo "<th>" . __("Reference") . "</th>";
+                        echo "<th>" . __("Type") . "</th>";
+                        echo "<th>" . __("Model") . "</th>";
+                        echo "<th>" . __("Bill", "order") . "</th>";
+                        echo "<th>" . __("Bill status", "order") . "</th>";
+                        echo "</tr>";
+
+                        $results = $order_item->queryBills($order->getID(), $data_ref['id']);
+                        while ($data = $DB->fetch_array($results)) {
+                            echo "<tr class='tab_bg_1'>";
+                            if ($canedit) {
+                                echo "<td width='10'>";
+                                $sel = "";
+                                if (isset($_GET["select"]) && $_GET["select"] == "all") {
+                                    $sel = "checked";
+                                }
+                                echo "<input type='checkbox' name='item[" . $data["IDD"] . "]' value='1' $sel>";
+                                echo "<input type='hidden' name='plugin_order_orders_id' value='" .
+                                $order->getID() . "'>";
+                                echo "</td>";
+                            }
+                            
+
+                            //Reference
+                            echo "<td align='center'>";
+                            echo $reference->getReceptionReferenceLink($data);
+                            echo "</td>";
+
+                            //Type
+                            echo "<td align='center'>";
+                            if (file_exists($CFG_GLPI['root_doc'] . "/inc/" . strtolower($data["itemtype"]) . "type.class.php")) {
+                                echo Dropdown::getDropdownName(getTableForItemType($data["itemtype"] . "Type"), $data["types_id"]);
+                            }
+                            echo "</td>";
+
+                            //Model
+                            echo "<td align='center'>";
+                            if (file_exists($CFG_GLPI['root_doc'] . "/inc/" . strtolower($data["itemtype"]) . "model.class.php")) {
+                                echo Dropdown::getDropdownName(getTableForItemType($data["itemtype"] . "Model"), $data["models_id"]);
+                            }
+                            $bill = new PluginOrderBill();
+                            echo "<td align='center'>";
+                            if ($data["plugin_order_bills_id"] > 0) {
+                                if ($bill->can($data['plugin_order_bills_id'], READ)) {
+                                    echo "<a href='" . $bill->getLinkURL() . "'>" . $bill->getName(true) . "</a>";
+                                } else {
+                                    echo $bill->getName();
+                                }
+                            }
+                            echo "</td>";
+                            echo "<td align='center'>";
+                            echo Dropdown::getDropdownName(getTableForItemType('PluginOrderBillState'), $data['plugin_order_billstates_id']);
+                            echo "</td>";
+                            echo "</tr>";
+                        }
+                        echo "</table></div>";
+                        echo "</td></tr>";
+                    }
+                }
+            }
+            echo "</table>";
+
+            echo "</div>";
+        } else {
+            echo "<div class='center'><table class='tab_cadre_fixe'>";
+            echo "<tr><th>" . __("No item to take delivery of", "order") . "</th></tr></table></div>";
+        }
+
+        if ($canedit) {
             echo "<div class='center'>";
             echo "<table width='950px' class='tab_glpi'>";
             echo "<tr><td><img src=\"" . $CFG_GLPI["root_doc"]
-               . "/pics/arrow-left.png\" alt=''></td><td class='center'>";
+            . "/pics/arrow-left.png\" alt=''></td><td class='center'>";
             echo "<a onclick= \"if ( markCheckboxes('bills_form$rand') ) "
-               . "return false;\" href='#'>" . __("Check all") . "</a></td>";
+            . "return false;\" href='#'>" . __("Check all") . "</a></td>";
 
             echo "<td>/</td><td class='center'>";
             echo "<a onclick= \"if ( unMarkCheckboxes('bills_form$rand') ) "
-               . "return false;\" href='#'>" . __("Uncheck all") . "</a>";
+            . "return false;\" href='#'>" . __("Uncheck all") . "</a>";
             echo "</td><td align='left' width='80%'>";
-            echo "<input type='hidden' name='plugin_order_orders_id' value='" . $order->getID() . "'>";
-            $order_item->dropdownBillItemsActions($order->getID());
-            echo "</td>";
-            echo "</table>";
-            echo "</div>";
-         }
-         Html::closeForm();
-         echo "</div>";
-      }
-      echo "<br>";
-   }
 
-   public static function install(Migration $migration) {
-      global $DB;
+            echo "<input type='hidden' name='plugin_order_bills_id' value='" . $bill_id . "'>";
+            $order_item->dropdownBillItemsActions($order->getID(), $bill_id);
+            /*echo "<input type='hidden' name='plugin_order_bills_id' value='" . $bill_id . "'>";
+            echo "&nbsp;<input type='submit' name='action' class='submit' value='" . _sx('button', 'Post') . "'>";*/
 
-      $table = getTableForItemType(__CLASS__);
+            echo "</td></tr>";
 
-      if (!TableExists($table)) {
-         $migration->displayMessage("Installing $table");
-         $query ="CREATE TABLE IF NOT EXISTS `glpi_plugin_order_bills` (
+
+            echo "<tr><td>";
+
+            $req_orders_add = "SELECT id, concat(name,' ', order_date) from glpi_plugin_order_orders " .
+                    "where id in ( SELECT plugin_order_orders_id FROM `glpi_plugin_order_orders_items` " .
+                    "where plugin_order_bills_id=0 ".
+                    "OR plugin_order_bills_id='" . $bill_id . "' GROUP BY plugin_order_orders_id) " .
+                    "AND id not in (SELECT glpi_plugin_order_orders_id FROM glpi_plugin_order_billsorder) " .
+                    "AND suppliers_id='" . $bill_supplier . "'";
+            $result_req_orders_add = $DB->query($req_orders_add);
+            if ($DB->numrows($result_req_orders_add)) {
+                echo "<p> Commande à facturer";
+                echo "<Select name ='order_to_add'>";
+                while ($order_add = $DB->fetch_array($result_req_orders_add)) {
+
+                    echo "<option value='" . $order_add[0] . "'>" . $order_add[1] . "</option>";
+                }
+                echo "</select></p>";
+
+
+                echo "<input type='hidden' name='plugin_order_bills_id' value='" . $bill_id . "'>";
+                echo "&nbsp;<input type='submit' name='action' class='submit' value='" . _sx('button', 'Add') . "'>";
+
+                echo "</td></tr></table>";
+                echo "</div>";
+            }
+        }
+
+        Html::closeForm();
+
+
+        echo "<br>";
+    }
+
+    public static function install(Migration $migration) {
+        global $DB;
+
+        $table = getTableForItemType(__CLASS__);
+
+        if (!TableExists($table)) {
+            $migration->displayMessage("Installing $table");
+            $query = "CREATE TABLE IF NOT EXISTS `glpi_plugin_order_bills` (
                     `id` int(11) NOT NULL AUTO_INCREMENT,
                     `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
                     `number` varchar(255) COLLATE utf8_unicode_ci DEFAULT '',
@@ -418,95 +469,91 @@ class PluginOrderBill extends CommonDropdown
                     `value` decimal(20,6) NOT NULL DEFAULT '0.000000',
                     `plugin_order_billtypes_id` int(11) NOT NULL DEFAULT '0',
                     `suppliers_id` int(11) NOT NULL DEFAULT '0',
-                    `plugin_order_orders_id` int(11) NOT NULL DEFAULT '0',
                     `users_id_validation` int(11) NOT NULL DEFAULT '0',
                     `entities_id` int(11) NOT NULL DEFAULT '0',
                     `is_recursive` int(11) NOT NULL DEFAULT '0',
                     `notepad` text COLLATE utf8_unicode_ci,
                     PRIMARY KEY (`id`)
                   ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ;";
-         $DB->query($query) or die ($DB->error());
-      } else {
-         if (FieldExists("glpi_plugin_order_orders_suppliers", "num_bill")) {
-            //Migrate bills
-            $bill  = new PluginOrderBill();
-            $query = "SELECT * FROM `glpi_plugin_order_orders_suppliers`";
-            foreach (getAllDatasFromTable('glpi_plugin_order_orders_suppliers') as $data) {
-               if (!is_null($data['num_bill'])
-                  && $data['num_bill'] != ''
-                     && !countElementsInTable('glpi_plugin_order_bills',
-                                              "`number`='".$data['num_bill']."'")) {
-                  //create new bill and link it to the order
-                  $tmp['name']                   = $tmp['number'] = $data['num_bill'];
+            $DB->query($query) or die($DB->error());
+        } else {
+            if (FieldExists("glpi_plugin_order_orders_suppliers", "num_bill")) {
+                //Migrate bills
+                $bill = new PluginOrderBill();
+                $query = "SELECT * FROM `glpi_plugin_order_orders_suppliers`";
+                foreach (getAllDatasFromTable('glpi_plugin_order_orders_suppliers') as $data) {
+                    if (!is_null($data['num_bill']) && $data['num_bill'] != '' && !countElementsInTable('glpi_plugin_order_bills', "`number`='" . $data['num_bill'] . "'")) {
+                        //create new bill and link it to the order
+                        $tmp['name'] = $tmp['number'] = $data['num_bill'];
 
-                  //Get supplier from the order
-                  $tmp['suppliers_id']           = $data['suppliers_id'];
+                        //Get supplier from the order
+                        $tmp['suppliers_id'] = $data['suppliers_id'];
 
-                  //Bill has the same entities_id and is_recrusive
-                  $tmp['entities_id']            = $data['entities_id'];
-                  $tmp['is_recursive']           = $data['is_recursive'];
-                  //Link bill to order
-                  $tmp['plugin_order_orders_id'] = $data['plugin_order_orders_id'];
-                  //Create bill
-                  $bills_id                      = $bill->add($tmp);
+                        //Bill has the same entities_id and is_recrusive
+                        $tmp['entities_id'] = $data['entities_id'];
+                        $tmp['is_recursive'] = $data['is_recursive'];
+                        //Link bill to order
+                        $tmp['plugin_order_orders_id'] = $data['plugin_order_orders_id'];
+                        //Create bill
+                        $bills_id = $bill->add($tmp);
 
-                  //All order items are now linked to this bill
-                  $query = "UPDATE `glpi_plugin_order_orders_items`
+                        //All order items are now linked to this bill
+                        $query = "UPDATE `glpi_plugin_order_orders_items`
                             SET `plugin_order_bills_id` = '$bills_id'
                             WHERE `plugin_order_orders_id` = '" . $data['plugin_order_orders_id'] . "'";
-                  $DB->query($query);
-               }
+                        $DB->query($query);
+                    }
+                }
             }
-          }
-         $migration->changeField($table, "value", "value", "decimal(20,6) NOT NULL DEFAULT '0.000000'");
-         $migration->migrationOneTable($table);
-       }
-      $migration->dropField("glpi_plugin_order_orders_suppliers", "num_bill");
-      $migration->migrationOneTable("glpi_plugin_order_orders_suppliers");
-   }
+            $migration->changeField($table, "value", "value", "decimal(20,6) NOT NULL DEFAULT '0.000000'");
+            $migration->migrationOneTable($table);
+        }
+        $migration->dropField("glpi_plugin_order_orders_suppliers", "num_bill");
+        $migration->migrationOneTable("glpi_plugin_order_orders_suppliers");
+    }
 
-   public static function uninstall() {
-      global $DB;
+    public static function uninstall() {
+        global $DB;
 
-      $table = getTableForItemType(__CLASS__);
-      foreach (array("displaypreferences", "documents_items", "bookmarks", "logs") as $t) {
-         $query = "DELETE FROM `glpi_$t` WHERE `itemtype` = '" . __CLASS__ . "'";
-         $DB->query($query);
-      }
-      $DB->query("DROP TABLE IF EXISTS`" . $table . "`") or die ($DB->error());
-   }
+        $table = getTableForItemType(__CLASS__);
+        foreach (array("displaypreferences", "documents_items", "bookmarks", "logs") as $t) {
+            $query = "DELETE FROM `glpi_$t` WHERE `itemtype` = '" . __CLASS__ . "'";
+            $DB->query($query);
+        }
+        $DB->query("DROP TABLE IF EXISTS`" . $table . "`") or die($DB->error());
+    }
 
-   public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
-      if (!$withtemplate) {
-         switch ($item->getType()) {
-            case 'PluginOrderOrder':
-               return self::getTypeName();
-               break;
-            case __CLASS__:
-               $ong[1] = __("Orders", "order");
-               $ong[2] = _n("Associated item", "Associated items", 2);
-               return $ong;
-         }
-      }
-      return '';
-   }
+    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
+        if (!$withtemplate) {
+            switch ($item->getType()) {
+                case 'PluginOrderOrder':
+                    return self::getTypeName();
+                    break;
+                case __CLASS__:
+                    $ong[1] = __("Orders", "order");
+                    $ong[2] = _n("Associated item", "Associated items", 2);
+                    return $ong;
+            }
+        }
+        return '';
+    }
 
-   public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
+    public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
 
-      if ($item->getType() == 'PluginOrderOrder') {
-         $order_item = new PluginOrderOrder_Item();
-         $order_item->showBillsItems($item);
+        if ($item->getType() == 'PluginOrderOrder') {
+            $order_item = new PluginOrderOrder_Item();
+            $order_item->showBillsItems($item);
+        } elseif ($item->getType() == __CLASS__) {
+            switch ($tabnum) {
+                case 1 :
+                    self::showOrdersItems($item);
+                    break;
+                case 2 :
+                    self::showItems($item);
+                    break;
+            }
+        }
+        return true;
+    }
 
-      } elseif ($item->getType() == __CLASS__) {
-         switch ($tabnum) {
-            case 1 :
-               self::showOrdersItems($item);
-               break;
-            case 2 :
-               self::showItems($item);
-               break;
-         }
-      }
-      return true;
-   }
 }

--- a/inc/billorder.class.php
+++ b/inc/billorder.class.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ LICENSE
+
+ This file is part of the order plugin.
+
+ Order plugin is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ Order plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with GLPI; along with Order. If not, see <http://www.gnu.org/licenses/>.
+ --------------------------------------------------------------------------
+ @package   order
+ @author    the order plugin team
+ @copyright Copyright (c) 2010-2015 Order plugin team
+ @license   GPLv2+
+            http://www.gnu.org/licenses/gpl.txt
+ @link      https://forge.indepnet.net/projects/order
+ @link      http://www.glpi-project.org/
+ @since     2009
+ ---------------------------------------------------------------------- */
+
+if (!defined('GLPI_ROOT')){
+   die("Sorry. You can't access directly to this file");
+}
+
+class PluginOrderBillOrder extends CommonDropdown
+{
+   public static $rightname  = 'plugin_order_billorder';
+   
+
+   public static function getTypeName($nb = 0) {
+      return __("Bill", "order");
+   }
+
+   public function post_getEmpty() {
+      $this->fields['value'] = 0;
+   }
+
+   
+
+  
+
+  
+
+   
+
+  
+
+   public static function install(Migration $migration) {
+      global $DB;
+
+      $table = "glpi_plugin_order_billsorder";
+
+      if (!TableExists($table)) {
+         $migration->displayMessage("Installing $table");
+         $query ="CREATE TABLE IF NOT EXISTS `glpi_plugin_order_billsorder` (
+             `id` int(11) NOT NULL AUTO_INCREMENT,
+                    `glpi_plugin_order_orders_id` int(11) NOT NULL DEFAULT '0',
+                    `glpi_plugin_order_bills_id` int(11) NOT NULL DEFAULT '0',
+                    PRIMARY KEY (`id`)
+                  ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci ;";
+         $DB->query($query) or die ($DB->error());
+      } 
+      
+   }
+
+   public static function uninstall() {
+      global $DB;
+
+      $table = "glpi_plugin_order_billsorder";
+      
+      $DB->query("DROP TABLE IF EXISTS`" . $table . "`") or die ($DB->error());
+   }
+
+
+}


### PR DESCRIPTION
Je ne connais pas bien GLPI et le plugin order donc le code est à nettoyer
Voilà ce que j'ai fait:
Ajout dans le hook la nouvelle classe billorder.class
Dans cette classe:
Création d'une nouvelle table qui va associer les id des commandes au id des factures

Dans la page de création de facture: suppresion du champ commande
Dans la page modificatiion d'une facture dans l'onglet commande
On va lire la table glpi_plugin_order_billsorder pour lister les commandes liée à la facture
Ajout d'un dropdownlist (code à revoir) pour lister les commandes du même fournisseur dont au moins un article n'est pas lié à une facture
Ajout d'un bouton ajouter pour ajouter une commande à une facture
J'ai supprimé dans commande la possibilité de l'associer à une facture (multiplication des fonctions)
Modification de l'affichage des commandes, modification de l'ajax billaction
on considère que lorsque l'on coche un article, que l'on associe à une facture, c'et à la facture en cours d'affichage

Modification visuelle de la page élément rattachés
Merci
