### PR TITLE
Missing getTable function preventing data injection

### DIFF
--- a/inc/orderinjection.class.php
+++ b/inc/orderinjection.class.php
@@ -32,7 +32,7 @@ if (!defined('GLPI_ROOT')) {
 }
 
 class PluginOrderOrderInjection extends PluginOrderOrder implements PluginDatainjectionInjectionInterface {
-   function __construct() {
+   public function __construct() {
       $this->table = getTableForItemType(get_parent_class($this));
    }
 
@@ -42,11 +42,11 @@ class PluginOrderOrderInjection extends PluginOrderOrder implements PluginDatain
        return $parenttype::getTable();
     }
  
-   function isPrimaryType() {
+   public function isPrimaryType() {
       return true;
    }
 
-   function connectedTo() {
+   public function connectedTo() {
       return array();
    }
 
@@ -58,13 +58,13 @@ class PluginOrderOrderInjection extends PluginOrderOrder implements PluginDatain
     * @return an array of IDs of newly created objects : for example array(Computer=>1, Networkport=>10)
     *
    **/
-   function addOrUpdateObject($values=array(), $options=array()) {
+   public function addOrUpdateObject($values=array(), $options=array()) {
       $lib = new PluginDatainjectionCommonInjectionLib($this, $values, $options);
       $lib->processAddOrUpdate();
       return $lib->getInjectionResults();
    }
 
-   function getOptions($primary_type = '') {
+   public function getOptions($primary_type = '') {
       return Search::getOptions(get_parent_class($this));
    }
 }

--- a/inc/orderinjection.class.php
+++ b/inc/orderinjection.class.php
@@ -32,15 +32,21 @@ if (!defined('GLPI_ROOT')) {
 }
 
 class PluginOrderOrderInjection extends PluginOrderOrder implements PluginDatainjectionInjectionInterface {
-   public function __construct() {
+   function __construct() {
       $this->table = getTableForItemType(get_parent_class($this));
    }
 
-   public function isPrimaryType() {
+    static function getTable() {
+     
+       $parenttype = get_parent_class();
+       return $parenttype::getTable();
+    }
+ 
+   function isPrimaryType() {
       return true;
    }
 
-   public function connectedTo() {
+   function connectedTo() {
       return array();
    }
 
@@ -52,13 +58,13 @@ class PluginOrderOrderInjection extends PluginOrderOrder implements PluginDatain
     * @return an array of IDs of newly created objects : for example array(Computer=>1, Networkport=>10)
     *
    **/
-   public function addOrUpdateObject($values=array(), $options=array()) {
+   function addOrUpdateObject($values=array(), $options=array()) {
       $lib = new PluginDatainjectionCommonInjectionLib($this, $values, $options);
       $lib->processAddOrUpdate();
       return $lib->getInjectionResults();
    }
 
-   public function getOptions($primary_type = '') {
+   function getOptions($primary_type = '') {
       return Search::getOptions(get_parent_class($this));
    }
 }

--- a/inc/orderinjection.class.php
+++ b/inc/orderinjection.class.php
@@ -35,7 +35,12 @@ class PluginOrderOrderInjection extends PluginOrderOrder implements PluginDatain
    public function __construct() {
       $this->table = getTableForItemType(get_parent_class($this));
    }
-
+   
+   /**
+    * Returns the name of the table used to store this object parent
+    *
+    * @return string (table name)
+   **/
     static function getTable() {
      
        $parenttype = get_parent_class();

--- a/inc/referenceinjection.class.php
+++ b/inc/referenceinjection.class.php
@@ -32,7 +32,7 @@ if (!defined('GLPI_ROOT')) {
 }
 
 class PluginOrderReferenceInjection extends PluginOrderReference implements PluginDatainjectionInjectionInterface {
-   function __construct() {
+   public function __construct() {
       $this->table = getTableForItemType(get_parent_class($this));
    }
 
@@ -42,11 +42,11 @@ class PluginOrderReferenceInjection extends PluginOrderReference implements Plug
       return $parenttype::getTable();
    } 
  
-   function isPrimaryType() {
+   public function isPrimaryType() {
       return true;
    }
 
-   function connectedTo() {
+   public function connectedTo() {
       return array();
    }
 
@@ -58,17 +58,17 @@ class PluginOrderReferenceInjection extends PluginOrderReference implements Plug
     * @return an array of IDs of newly created objects : for example array(Computer=>1, Networkport=>10)
     *
    **/
-   function addOrUpdateObject($values=array(), $options=array()) {
+   public function addOrUpdateObject($values=array(), $options=array()) {
       $lib = new PluginDatainjectionCommonInjectionLib($this, $values, $options);
       $lib->processAddOrUpdate();
       return $lib->getInjectionResults();
    }
 
-   function getOptions($primary_type = '') {
+   public function getOptions($primary_type = '') {
       return Search::getOptions(get_parent_class($this));
    }
 
-   function getSpecificFieldValue($itemtype, $searchOption, $field, &$values) {
+   public function getSpecificFieldValue($itemtype, $searchOption, $field, &$values) {
       global $DB;
 
       $value  = $values[$itemtype][$field];

--- a/inc/referenceinjection.class.php
+++ b/inc/referenceinjection.class.php
@@ -32,15 +32,21 @@ if (!defined('GLPI_ROOT')) {
 }
 
 class PluginOrderReferenceInjection extends PluginOrderReference implements PluginDatainjectionInjectionInterface {
-   public function __construct() {
+   function __construct() {
       $this->table = getTableForItemType(get_parent_class($this));
    }
 
-   public function isPrimaryType() {
+   static function getTable() {
+    
+      $parenttype = get_parent_class();
+      return $parenttype::getTable();
+   } 
+ 
+   function isPrimaryType() {
       return true;
    }
 
-   public function connectedTo() {
+   function connectedTo() {
       return array();
    }
 
@@ -52,17 +58,17 @@ class PluginOrderReferenceInjection extends PluginOrderReference implements Plug
     * @return an array of IDs of newly created objects : for example array(Computer=>1, Networkport=>10)
     *
    **/
-   public function addOrUpdateObject($values=array(), $options=array()) {
+   function addOrUpdateObject($values=array(), $options=array()) {
       $lib = new PluginDatainjectionCommonInjectionLib($this, $values, $options);
       $lib->processAddOrUpdate();
       return $lib->getInjectionResults();
    }
 
-   public function getOptions($primary_type = '') {
+   function getOptions($primary_type = '') {
       return Search::getOptions(get_parent_class($this));
    }
 
-   public function getSpecificFieldValue($itemtype, $searchOption, $field, &$values) {
+   function getSpecificFieldValue($itemtype, $searchOption, $field, &$values) {
       global $DB;
 
       $value  = $values[$itemtype][$field];

--- a/inc/referenceinjection.class.php
+++ b/inc/referenceinjection.class.php
@@ -35,7 +35,12 @@ class PluginOrderReferenceInjection extends PluginOrderReference implements Plug
    public function __construct() {
       $this->table = getTableForItemType(get_parent_class($this));
    }
-
+   
+   /**
+    * Returns the name of the table used to store this object parent
+    *
+    * @return string (table name)
+   **/
    static function getTable() {
     
       $parenttype = get_parent_class();


### PR DESCRIPTION
The static function getTable() was missing from both orderinjection.class.php and referenceinjection.class.php files causing wrong table names to be used in datainjection plugin

This solves issue #67