### PR TITLE
Create missing directories at install and move files

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -73,6 +73,29 @@ function plugin_order_install() {
    echo "</table>";
    echo "</center>";
 
+   //Create directories for the plugin's files
+   $directories = [PLUGIN_ORDER_TEMPLATE_DIR        => 'templates',
+                   PLUGIN_ORDER_SIGNATURE_DIR       => 'signatures',
+                   PLUGIN_ORDER_TEMPLATE_CUSTOM_DIR => 'generate',
+                   PLUGIN_ORDER_TEMPLATE_LOGO_DIR   => 'logo'
+                  ];
+   foreach ($directories as $new_directory => $old_directory) {
+      if (!is_dir($new_directory)) {
+                  @mkdir($new_directory, 0777, true)
+                     or die(sprintf(__('%1$s %2$s'), __("Can't create folder", 'order'),
+                                    $new_directory));
+         $base_directory = GLPI_ROOT.'/plugins/order/';
+         //Copy files from the old directories to the new ones
+         foreach (glob($base_directory.$old_directory.'/*') as $file) {
+            $new_file = str_replace($base_directory.$old_directory, $new_directory, $file);
+            if (!file_exists($new_directory.$file)) {
+               copy($file, $new_file)
+                  or die (sprintf(__('Cannot copy file %1$s to %2$s', 'order'),
+                           $file, $new_file));
+            }
+         }
+      }
+   }
    return true;
 }
 

--- a/hook.php
+++ b/hook.php
@@ -81,7 +81,7 @@ function plugin_order_install() {
                   ];
    foreach ($directories as $new_directory => $old_directory) {
       if (!is_dir($new_directory)) {
-                  @mkdir($new_directory, 0777, true)
+                  @mkdir($new_directory, 0755, true)
                      or die(sprintf(__('%1$s %2$s'), __("Can't create folder", 'order'),
                                     $new_directory));
          $base_directory = GLPI_ROOT.'/plugins/order/';


### PR DESCRIPTION
Plugin installation doesn't create directories under glpi/plugins/_order
The following request create the missing directories, and copy the files from template, signature, logo and generate in the newly created directories.