### PR TITLE
Fix warning on price computation if no VAT selected; fixes #155

### DIFF
--- a/generate/custom.php.example
+++ b/generate/custom.php.example
@@ -148,11 +148,14 @@ function plugin_order_getCustomFieldsForODT($ID, $odttemplates_id, $odf, $signat
    $odf->mergeSegment($article);
    $prices = $PluginOrderOrder_Item->getAllPrices($ID);
 
-    // total price (with postage)
-   $postagewithTVA =
-   $PluginOrderOrder_Item->getPricesATI($order->fields["port_price"],
-                                         Dropdown::getDropdownName("glpi_plugin_order_ordertaxes",
-                                                                   $order->fields["plugin_order_ordertaxes_id"]));
+   // total price (with postage)
+   $tax = new PluginOrderOrderTax();
+   $tax->getFromDB($order->fields["plugin_order_ordertaxes_id"]);
+
+   $postagewithTVA = $PluginOrderOrder_Item->getPricesATI(
+      $order->fields["port_price"],
+      $tax->getRate()
+   );
 
    $total_HT  = $prices["priceHT"] + $order->fields["port_price"];
    $total_TVA = $prices["priceTVA"] + $postagewithTVA - $order->fields["port_price"];

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -1150,8 +1150,13 @@ class PluginOrderOrder extends CommonDBTM {
          echo "</tr>";
 
          // total price (with postage)
-         $postagewithTVA = $PluginOrderOrder_Item->getPricesATI($this->fields["port_price"],
-            Dropdown::getDropdownName("glpi_plugin_order_ordertaxes", $this->fields["plugin_order_ordertaxes_id"]));
+         $tax = new PluginOrderOrderTax();
+         $tax->getFromDB($this->fields["plugin_order_ordertaxes_id"]);
+
+         $postagewithTVA = $PluginOrderOrder_Item->getPricesATI(
+            $this->fields["port_price"],
+            $tax->getRate()
+         );
 
          $priceHTwithpostage = $prices["priceHT"] + $this->fields["port_price"];
          echo "<tr>";
@@ -1665,9 +1670,13 @@ class PluginOrderOrder extends CommonDBTM {
             $prices = $PluginOrderOrder_Item->getAllPrices($ID);
 
             // total price (with postage)
-            $postagewithTVA = $PluginOrderOrder_Item->getPricesATI($this->fields["port_price"],
-                                                                   Dropdown::getDropdownName("glpi_plugin_order_ordertaxes",
-                                                                   $this->fields["plugin_order_ordertaxes_id"]));
+            $tax = new PluginOrderOrderTax();
+            $tax->getFromDB($this->fields["plugin_order_ordertaxes_id"]);
+
+            $postagewithTVA = $PluginOrderOrder_Item->getPricesATI(
+               $this->fields["port_price"],
+               $tax->getRate()
+            );
 
             $total_HT  = $prices["priceHT"] + $this->fields["port_price"];
             $total_TVA = $prices["priceTVA"] + $postagewithTVA - $this->fields["port_price"];
@@ -1793,12 +1802,17 @@ class PluginOrderOrder extends CommonDBTM {
 
          $total = 0;
          foreach ($DB->request($query_limit) as $data) {
-
             $PluginOrderOrder_Item = new PluginOrderOrder_Item();
             $prices                = $PluginOrderOrder_Item->getAllPrices($data["id"]);
-            $postagewithTVA        = $PluginOrderOrder_Item->getPricesATI($data["port_price"],
-                                                    Dropdown::getDropdownName("glpi_plugin_order_ordertaxes",
-                                                                              $data["plugin_order_ordertaxes_id"]));
+
+            $tax = new PluginOrderOrderTax();
+            $tax->getFromDB($data["plugin_order_ordertaxes_id"]);
+
+            $postagewithTVA        = $PluginOrderOrder_Item->getPricesATI(
+               $data["port_price"],
+               $tax->getRate()
+            );
+
             //if state is cancel do not decremente total already use
             if ($data['plugin_order_orderstates_id'] < 5) {
                $total += $prices["priceHT"];

--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -252,8 +252,12 @@ class PluginOrderOrder_Item extends CommonDBRelation {
 
 
    public function addDetails($ref_id, $itemtype, $orders_id, $quantity, $price, $discounted_price, $taxes_id) {
+
       $order = new PluginOrderOrder();
       if ($quantity > 0 && $order->getFromDB($orders_id)) {
+         $tax = new PluginOrderOrderTax();
+         $tax->getFromDB($taxes_id);
+
          for ($i = 0; $i < $quantity; $i++) {
             $input["plugin_order_orders_id"]     = $orders_id;
             $input["plugin_order_references_id"] = $ref_id;
@@ -264,10 +268,10 @@ class PluginOrderOrder_Item extends CommonDBRelation {
             $input["price_taxfree"]              = $price;
             $input["price_discounted"]           = $price - ($price * ($discounted_price / 100));
             $input["states_id"]                  = PluginOrderOrder::ORDER_DEVICE_NOT_DELIVRED;;
-
-            $input["price_ati"]                  = $this->getPricesATI($input["price_discounted"],
-                                                                       Dropdown::getDropdownName("glpi_plugin_order_ordertaxes",
-                                                                                                 $taxes_id));
+            $input["price_ati"]                  = $this->getPricesATI(
+               $input["price_discounted"],
+               $tax->getRate()
+            );
             $input["discount"]                   = $discounted_price;
 
             $this->add($input);
@@ -1357,8 +1361,11 @@ class PluginOrderOrder_Item extends CommonDBRelation {
       $input["price_taxfree"]     = $post['price_taxfree'];
       $input["price_discounted"]  = $input["price_taxfree"] - ($input["price_taxfree"] * ($discount / 100));
 
-      $taxe_name                  = Dropdown::getDropdownName("glpi_plugin_order_ordertaxes", $plugin_order_ordertaxes_id);
-      $input["price_ati"]         = $this->getPricesATI($input["price_discounted"], $taxe_name);
+      $tax = new PluginOrderOrderTax();
+      $tax->getFromDB($plugin_order_ordertaxes_id);
+
+      $input["price_ati"]         = $this->getPricesATI($input["price_discounted"], $tax->getRate());
+
       $this->update($input);
    }
 
@@ -1374,8 +1381,11 @@ class PluginOrderOrder_Item extends CommonDBRelation {
       $input["discount"]            = $post['discount'];
       $input["price_discounted"]    = $post['price'] - ($post['price'] * ($input['discount'] / 100));
 
-      $taxe_name = Dropdown::getDropdownName("glpi_plugin_order_ordertaxes", $plugin_order_ordertaxes_id);
-      $input["price_ati"]  = $this->getPricesATI($input["price_discounted"], $taxe_name);
+      $tax = new PluginOrderOrderTax();
+      $tax->getFromDB($plugin_order_ordertaxes_id);
+
+      $input["price_ati"]  = $this->getPricesATI($input["price_discounted"], $tax->getRate());
+
       $this->update($input);
    }
 

--- a/inc/ordertax.class.php
+++ b/inc/ordertax.class.php
@@ -100,5 +100,17 @@ class PluginOrderOrderTax extends CommonDropdown {
       $DB->query("DROP TABLE IF EXISTS `".self::getTable()."`") or die ($DB->error());
    }
 
+   /**
+    * Get the tax rate of loaded item.
+    *
+    * @return number
+    */
+   public function getRate() {
 
+      if (array_key_exists('name', $this->fields) && !empty($this->fields['name'])) {
+         return floatval($this->fields['name']);
+      }
+
+      return 0;
+   }
 }


### PR DESCRIPTION
`Dropdown::getDropdownName()` function returns `&nbsp;` when item is not found in DB. So, when no VAT was selected, the applied rate was `&nbsp;` and a `A non-numeric value encountered in /usr/share/glpi/plugins/order/inc/order_item.class.php at line 243` warning was triggered.