### PR TITLE
Fix missing comment field in sample order template; fixes #172

### DIFF
--- a/generate/custom.php.example
+++ b/generate/custom.php.example
@@ -41,7 +41,7 @@ function plugin_order_getCustomFieldsForODT($ID, $odttemplates_id, $odf, $signat
 
    $odf->setVars('title_order', __("Order number", "order"), true, 'UTF-8');
    $odf->setVars('num_order', $order->fields["num_order"], true, 'UTF-8');
-   $odf->setVars('comment', $order->fields["comment"], true, 'UTF-8');
+   //$odf->setVars('comment', $order->fields["comment"], true, 'UTF-8');
 
    $odf->setVars('title_invoice_address', __("Invoice address", "order"), true, 'UTF-8');
 


### PR DESCRIPTION
There is no `{comment}` field in `example.odt` file, so users that just try to generate example have an error.