### PR TITLE
Fix survey supplier tab: fixes #173

### DIFF
--- a/inc/surveysupplier.class.php
+++ b/inc/surveysupplier.class.php
@@ -277,9 +277,10 @@ class PluginOrderSurveySupplier extends CommonDBChild {
          $this->check($ID, READ);
       } else {
          // Create item
-         $this->check(-1, UPDATE, [
+         $input = [
             'plugin_order_orders_id' => $options['plugin_order_orders_id']
-         ]);
+         ];
+         $this->check(-1, UPDATE, $input);
       }
 
       $this->initForm($ID, $options);


### PR DESCRIPTION
`check` functions uses reference for its third parameter, so it is not possible to pass a volatile array.