### PR TITLE
Add ability to enable document renaming feature

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -215,6 +215,13 @@ class PluginOrderConfig extends CommonDBTM {
       echo "</td>";
       echo "</tr>";
 
+      echo "<tr class='tab_bg_1' align='center'>";
+      echo "<td>" . __("Rename documents added in order", 'order') . "</td>";
+      echo "<td>";
+      Dropdown::showYesNo("rename_documents", $this->fields["rename_documents"]);
+      echo "</td>";
+      echo "</tr>";
+
       // Automatic actions
       echo "<tr class='tab_bg_1' align='center'>";
       echo "<th colspan='2'>".__("Automatic actions when delivery", "order")."</th>";


### PR DESCRIPTION
Users were not able to enable the "Document renaming" feature after commit 24d2350334f0ab7eaef014372da4946f9a2b3534. I put back corresponding configuration option to test this feature and it seems to work.

Feature is still enabled for users which enabled this feature before 0.85+1.1.

Enabling this feature has following effects.
1) All documents added to an order has their filename changed to `{$order_num}.{$file_extension}`. It can lead to duplicates filenames.
2) A prefix can be defined in an `Order` tab in document categories and will be added to all documents added to an order.