### PR TITLE
Fix delivery item count in GLPI 9.3.0; fixes #201

### DIFF
--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -1134,7 +1134,7 @@ class PluginOrderOrder_Item extends CommonDBRelation {
             'plugin_order_references_id' => $references_id,
             'price_taxfree'              => ['LIKE', $price_taxfree],
             'discount'                   => ['LIKE', $discount],
-            'states_id'                  => ['!=', 0],
+            'states_id'                  => ['<>', 0],
          ]
       );
    }


### PR DESCRIPTION
`!=` operator was added recently and will be introduced in 9.3.1 version of GLPI. Using it in a previous version makes a request like ``WHERE `column` IN ('!=', 'value')``, which is the exact opposite as expected ``WHERE `column` != 'value'``.