### PR TITLE
clean unused input vars, fix #69

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -143,7 +143,7 @@ class PluginOrderLink extends CommonDBChild {
 
             echo "<td align='center'>";
             if ($templateID) {
-               echo $reference->getTemplateName($params['add_items'][$key]['itemtype'], $templateID);
+               echo $reference->getTemplateName($itemtype, $templateID);
             }
             echo "</td>";
 


### PR DESCRIPTION
see also #205 

I can't see any usage in massive action methods of the cleaned keys.

With this clean, we have "only" `8 + nb_items * 3` (instead *7)  in input vars passed within the massiveaction ajax POST
so we can now have 330 items for default 1000 in max_input_vars.

I can certainly remove also the two last:
 - plugin_order_references_id
 - itemtype

but it means doing getFromDB calls in massive action processing, so a much longer processing.
Or instead, maybe we can do the retrieval of additional data by a global query with a IN for all passed id.
