### PR TITLE
Remove buy_date protection

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -857,6 +857,7 @@ class PluginOrderLink extends CommonDBChild {
          $fields["suppliers_id"]    = $order->fields["suppliers_id"];
          $fields["value"]           = $detail->fields["price_discounted"];
          $fields["order_date"]      = $order->fields["order_date"];
+         $fields["buy_date"]        = $order->fields["order_date"];
 
          if (!is_null($detail->fields["delivery_date"])) {
             $fields["delivery_date"] = $detail->fields["delivery_date"];

--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -210,7 +210,7 @@ class PluginOrderOrder_Item extends CommonDBRelation {
                      default:
                         $field_set    = false;
                         $unset_fields = ["order_number", "delivery_number", "budgets_id",
-                                         "suppliers_id", "value", "buy_date"];
+                                         "suppliers_id", "value"];
                         $orderitem->getFromDB($detail_id);
                         $order->getFromDB($orderitem->fields["plugin_order_orders_id"]);
                         $order_supplier->getFromDBByOrder($orderitem->fields["plugin_order_orders_id"]);
@@ -220,7 +220,6 @@ class PluginOrderOrder_Item extends CommonDBRelation {
                         $value["budgets_id"]      = $order->fields["budgets_id"];
                         $value["suppliers_id"]    = $order->fields["suppliers_id"];
                         $value["value"]           = $orderitem->fields["price_discounted"];
-                        $value["buy_date"]        = $order->fields["order_date"];
                         if (isset($order_supplier->fields["num_bill"])
                            && !empty($order_supplier->fields["num_bill"])) {
                            $unset_fields[]        = "bill";


### PR DESCRIPTION
Order object has no `buy_date` fields, so infocom `buy_date` is generated using the `order_date` value from the order object. The problem is that sometimes, it may be required to be able to define a different value for `buy_date` and `order_date` in infocom fields, but this is prevented by plugin.

This PR removes the protection on `buy_date` infocom field.

Internal id: 15908.