### PR TITLE
Fix order references search results; fixes #230

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -303,7 +303,9 @@ function plugin_order_giveItem($type, $ID, $data, $num) {
    $field     = $searchopt[$ID]["field"];
    $reference = new PluginOrderReference();
    $itemnum   = $data['raw']["ITEM_".$num];
-   $itemtype  = isset($data['raw']["itemtype"]) ? $data['raw']["itemtype"] : "";
+   $itemtype  = isset($data['raw']["ITEM_".$num."_itemtype"])
+      ? $data['raw']["ITEM_".$num."_itemtype"]
+      : '';
 
    switch ($table.'.'.$field) {
       /* display associated items with order */
@@ -314,7 +316,7 @@ function plugin_order_giveItem($type, $ID, $data, $num) {
             $file = GLPI_ROOT."/inc/".strtolower($itemtype)."type.class.php";
          }
          if (file_exists($file)) {
-            return Dropdown::getDropdownName(getTableForItemType($data["itemtype"]."Type"),
+            return Dropdown::getDropdownName(getTableForItemType($itemtype."Type"),
                                              $itemnum);
          } else {
             return " ";

--- a/inc/reference.class.php
+++ b/inc/reference.class.php
@@ -106,6 +106,7 @@ class PluginOrderReference extends CommonDBTM {
          'injectable'    => true,
          'massiveaction' => false,
          'nosearch'      => true,
+         'additionalfields' => ['itemtype'],
       ];
 
       $tab[] = [
@@ -129,6 +130,7 @@ class PluginOrderReference extends CommonDBTM {
          'massiveaction' => false,
          'searchtype'    => ['equals'],
          'nosearch'      => true,
+         'additionalfields' => ['itemtype'],
       ];
 
       $tab[] = [
@@ -141,6 +143,7 @@ class PluginOrderReference extends CommonDBTM {
          'injectable'    => true,
          'massiveaction' => false,
          'nosearch'      => true,
+         'additionalfields' => ['itemtype'],
       ];
 
       $tab[] = [


### PR DESCRIPTION
`itemtype` have to be list in additional fields to be available in giveItem method. It's key will be `ITEM_{$itemtype}_{$so_id}_{$additional_field_name}`.