### PR TITLE
feat(core): display warning if plugin is not configured

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -488,6 +488,16 @@ class PluginOrderConfig extends CommonDBTM {
       return $this->fields['order_analyticnature_mandatory'];
    }
 
+   public function isConfigured() {
+      return ($this->fields['order_status_draft'] &&
+      $this->fields['order_status_waiting_approval'] &&
+      $this->fields['order_status_approved'] &&
+      $this->fields['order_status_partially_delivred'] &&
+      $this->fields['order_status_completly_delivered'] &&
+      $this->fields['order_status_canceled'] &&
+      $this->fields['order_status_paid']);
+   }
+
    public function getDefaultTaxes() {
       return $this->fields['default_taxes'];
    }

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -806,11 +806,23 @@ class PluginOrderOrder extends CommonDBTM {
    public function showForm ($ID, $options = []) {
       global $CFG_GLPI, $DB;
 
+      $config = PluginOrderConfig::getConfig();
+      if (!$config->isConfigured()) {
+
+         $link = "<a href='" . $config->getLinkURL(). "'>".__('Go to configuration page', 'order')."</a>";
+
+         echo "<div>";
+         echo "<span class='red fas fa-exclamation-triangle'>&nbsp;";
+         echo __('You must set up at least the order life cycle before starting.', 'order')." ".$link;
+         echo "</span>";
+         echo "</div>";
+         return;
+      }
+
       $this->initForm($ID, $options);
       $this->showFormHeader($options);
 
       $rand   = mt_rand();
-      $config = PluginOrderConfig::getConfig();
       $user   = new User();
 
       if (isset($options['withtemplate']) && $options['withtemplate'] == 2) {


### PR DESCRIPTION
Add message if order life cycle is not configured

![image](https://user-images.githubusercontent.com/7335054/120765284-57091780-c519-11eb-9a98-46fed972c3f6.png)
