### PR TITLE
fix(massiveaction): use getter instead of cast object to array

### DIFF
--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -734,15 +734,8 @@ class PluginOrderReception extends CommonDBChild {
 
       $detail                 = new PluginOrderOrder_Item();
       $plugin_order_orders_id = 0;
-      $ma                     = false;
 
-      // from MassiveAction process, we get ma object, so convert it into array
-      if (is_object($params)) {
-         $ma      = $params;
-         $params2 = (array) $params;
-      }
-
-      if (isset($params2['items'][__CLASS__])) {
+      if (isset($params->__get('items')[__CLASS__])) {
          $additional_data_ite = $DB->request([
             'SELECT' => [
                'glpi_plugin_order_orders_items.id',
@@ -761,7 +754,7 @@ class PluginOrderReception extends CommonDBChild {
                ]
             ],
             'WHERE' => [
-               'glpi_plugin_order_orders_items.id' => array_keys($params2['items'][__CLASS__])
+               'glpi_plugin_order_orders_items.id' => array_keys($params->__get('items')[__CLASS__])
             ]
          ]);
          $additional_data = [];
@@ -769,7 +762,7 @@ class PluginOrderReception extends CommonDBChild {
             $additional_data[$add_values['id']] = $add_values;
          }
 
-         foreach ($params2['items'][__CLASS__] as $key => $val) {
+         foreach ($params->__get('items')[__CLASS__] as $key => $val) {
             if ($val < 1) {
                 continue;
             }
@@ -777,12 +770,12 @@ class PluginOrderReception extends CommonDBChild {
             if ($add_data["itemtype"] == 'SoftwareLicense') {
                $this->receptionAllItem($key,
                                        $add_data["plugin_order_references_id"],
-                                       $params2['POST']["plugin_order_orders_id"],
-                                       $params2['POST']["delivery_date"],
-                                       $params2['POST']["delivery_number"],
-                                       $params2['POST']["plugin_order_deliverystates_id"]);
+                                       $params->getInput()["plugin_order_orders_id"],
+                                       $params->getInput()["delivery_date"],
+                                       $params->getInput()["delivery_number"],
+                                       $params->getInput()["plugin_order_deliverystates_id"]);
 
-               $plugin_order_orders_id = $params2['POST']["plugin_order_orders_id"];
+               $plugin_order_orders_id = $params->getInput()["plugin_order_orders_id"];
             } else {
                if ($detail->getFromDB($key)) {
                   if (!$plugin_order_orders_id) {
@@ -791,16 +784,16 @@ class PluginOrderReception extends CommonDBChild {
 
                   if ($detail->fields["states_id"] == PluginOrderOrder::ORDER_DEVICE_NOT_DELIVRED) {
                      $this->receptionOneItem($key, $plugin_order_orders_id,
-                                             $params2['POST']["delivery_date"],
-                                             $params2['POST']["delivery_number"],
-                                             $params2['POST']["plugin_order_deliverystates_id"]);
-                     if ($ma !== false) {
-                        $ma->itemDone(__CLASS__, $key, MassiveAction::ACTION_OK);
+                     $params->getInput()["delivery_date"],
+                     $params->getInput()["delivery_number"],
+                     $params->getInput()["plugin_order_deliverystates_id"]);
+                     if ($params !== false) {
+                        $params->itemDone(__CLASS__, $key, MassiveAction::ACTION_OK);
                      }
                   } else {
                      Session::addMessageAfterRedirect(__("Item already taken delivery", "order"), true, ERROR);
-                     if ($ma !== false) {
-                        $ma->itemDone(__CLASS__, $key, MassiveAction::ACTION_KO);
+                     if ($params !== false) {
+                        $params->itemDone(__CLASS__, $key, MassiveAction::ACTION_KO);
                      }
                   }
 
@@ -815,11 +808,11 @@ class PluginOrderReception extends CommonDBChild {
 
                   $config = PluginOrderConfig::getConfig(true);
                   if ($config->canGenerateAsset() == PluginOrderConfig::CONFIG_ASK) {
-                     $options['manual_generate'] = $params2['POST']['manual_generate'];
-                     if ($params2['POST']['manual_generate'] == 1) {
-                        $options['name']            = $params2['POST']['generated_name'];
-                        $options['serial']          = $params2['POST']['generated_serial'];
-                        $options['otherserial']     = $params2['POST']['generated_otherserial'];
+                     $options['manual_generate'] = $params->getInput()['manual_generate'];
+                     if ($params->getInput()['manual_generate'] == 1) {
+                        $options['name']            = $params->getInput()['generated_name'];
+                        $options['serial']          = $params->getInput()['generated_serial'];
+                        $options['otherserial']     = $params->getInput()['generated_otherserial'];
                      }
                   }
                   self::generateAsset($options);

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -735,7 +735,7 @@ class PluginOrderReception extends CommonDBChild {
       $detail                 = new PluginOrderOrder_Item();
       $plugin_order_orders_id = 0;
 
-      if (isset($params->__get('items')[__CLASS__])) {
+      if (isset($params->getItems()[__CLASS__])) {
          $additional_data_ite = $DB->request([
             'SELECT' => [
                'glpi_plugin_order_orders_items.id',
@@ -754,7 +754,7 @@ class PluginOrderReception extends CommonDBChild {
                ]
             ],
             'WHERE' => [
-               'glpi_plugin_order_orders_items.id' => array_keys($params->__get('items')[__CLASS__])
+               'glpi_plugin_order_orders_items.id' => array_keys($params->getItems()[__CLASS__])
             ]
          ]);
          $additional_data = [];
@@ -762,7 +762,7 @@ class PluginOrderReception extends CommonDBChild {
             $additional_data[$add_values['id']] = $add_values;
          }
 
-         foreach ($params->__get('items')[__CLASS__] as $key => $val) {
+         foreach ($params->getItems()[__CLASS__] as $key => $val) {
             if ($val < 1) {
                 continue;
             }


### PR DESCRIPTION
Since this PR
https://github.com/glpi-project/glpi/pull/10975

And particulary this change
https://github.com/glpi-project/glpi/pull/10975/files#diff-284b41ead4d268948c291846bcb61a98c51a0eebb76968e6d09a40b485909777

```MassiveAction``` (to update reception status) no longer works

Originally plugin cast ```MassiveAction``` object to ```array``` to handle ```items``` key

```php
      // from MassiveAction process, we get ma object, so convert it into array
      if (is_object($params)) {
         $ma      = $params;
         $params2 = (array) $params;
      }
```
But the variable is private now, it will have a weird key name (class + variable name) in the array.

Before  https://github.com/glpi-project/glpi/pull/10975
Casting MassiveAction Object to array return this

```
["items"]=> array(1) { ["PluginOrderReception"]=> array(2) { [6]=> string(1) "6" [7]=> string(1) "7" }
```

Now it return this

```
["MassiveActionitems"]=> array(1) { ["PluginOrderReception"]=> array(2) { [6]=> string(1) "6" [7]=> string(1) "7" }
```

This PR use ```getter``` from ```MassiveAction``` Object

Fix  internal !24000
