### PR TITLE
fix(html): close div

### DIFF
--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -500,6 +500,7 @@ class PluginOrderReception extends CommonDBChild {
             Html::closeForm();
          }
       }
+      echo "</div>";
       echo "<br>";
    }
 


### PR DESCRIPTION
In case of multiple reference, 

```Order``` display only one reference

We need to open first to get second

Before : 

![image](https://user-images.githubusercontent.com/7335054/169035881-0df99403-0802-454a-8cde-eb30fb9f3a76.png)

The second reference is embedded from the first

![image](https://user-images.githubusercontent.com/7335054/169036072-b24adc82-ac1f-4fc3-bc35-6442223e9a5b.png)


After : 

![image](https://user-images.githubusercontent.com/7335054/169035900-8292fb26-9db7-4ff4-b13c-8c799a2237b8.png)
