### PR TITLE
fix(massiveaction): permit bulk action

### DIFF
--- a/ajax/massreception.php
+++ b/ajax/massreception.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ LICENSE
+ This file is part of the order plugin.
+ Order plugin is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ Order plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with GLPI; along with Order. If not, see <http://www.gnu.org/licenses/>.
+ --------------------------------------------------------------------------
+ @package   order
+ @author    the order plugin team
+ @copyright Copyright (c) 2010-2015 Order plugin team
+ @license   GPLv2+
+            http://www.gnu.org/licenses/gpl.txt
+ @link      https://forge.indepnet.net/projects/order
+ @link      http://www.glpi-project.org/
+ @since     2009
+ ---------------------------------------------------------------------- */
+
+include ("../../../inc/includes.php");
+
+header("Content-Type: text/html; charset=UTF-8");
+
+Html::header_nocache();
+
+Session::checkLoginUser();
+
+$PluginOrderReception = new PluginOrderReception();
+
+echo "<table width='950px' class='tab_cadre_fixe'>";
+echo "<tr class='tab_bg_2'><td>" . __("Delivery date") . "</td><td>";
+Html::showDateField("delivery_date", [
+   'value'      => date("Y-m-d"),
+   'maybeempty' => true,
+   'canedit'    => true
+]);
+echo "</td><td>";
+echo __("Delivery form") . "</td><td>";
+echo "<input type='text' name='delivery_number' size='20'>";
+echo "</td><td>";
+echo Html::hidden('plugin_order_references_id', ['value' => $_POST["plugin_order_references_id"]]);
+echo Html::hidden('plugin_order_orders_id', ['value' => $_POST["plugin_order_orders_id"]]);
+echo __("Number to deliver", "order") . "</td><td width='10%'>";
+$nb = $PluginOrderReception->checkItemStatus($_POST['plugin_order_orders_id'],
+                                             $_POST['plugin_order_references_id'],
+                                             PluginOrderOrder::ORDER_DEVICE_NOT_DELIVRED);
+Dropdown::showNumber('number_reception', [
+   'value' => '',
+   'min'   => 1,
+   'max'   => $nb
+]);
+echo "</td><td>";
+echo __("Delivery status", "order") . "&nbsp;";
+PluginOrderDeliveryState::Dropdown(['name' => "plugin_order_deliverystates_id"]);
+echo "</td></tr>";
+
+echo "<tr class='tab_bg_2'>";
+$config = PluginOrderConfig::getConfig();
+if ($config->canGenerateAsset() == PluginOrderConfig::CONFIG_ASK) {
+   echo "<td>". __("Enable automatic generation", "order") . "</td>";
+   echo "<td>";
+   Dropdown::showYesNo("manual_generate", $config->canGenerateAsset());
+   echo "</td><td>" . __("Default name", "order") . "</td>";
+   echo "<td>&nbsp;";
+   Html::autocompletionTextField($config, "generated_name");
+   echo "</td>&nbsp;&nbsp;";
+
+   echo "<td>" . __("Default serial number", "order") . "</td>";
+   echo "<td>&nbsp;";
+   Html::autocompletionTextField($config, "generated_serial");
+   echo "</td>&nbsp;&nbsp;";
+
+   echo "<td>" . __("Default inventory number", "order") . "</td>";
+   echo "<td>&nbsp;";
+   Html::autocompletionTextField($config, "generated_otherserial");
+   echo "</td>";
+}
+echo "<td><input type='submit' name='bulk_reception' class='submit' value='"
+      . _sx('button', 'Post') . "'></td></tr></table>";
+
+Html::ajaxFooter();

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -500,6 +500,30 @@ class PluginOrderReception extends CommonDBChild {
             Html::closeForm();
          }
       }
+
+      if ($order_order->canDeliver()
+             && $this->checkItemStatus($orders_id,
+                                       $references_id,
+                                       PluginOrderOrder::ORDER_DEVICE_NOT_DELIVRED)) {
+
+            if ($typeRef != 'SoftwareLicense') {
+               echo "<form method='post' name='order_reception_form$rand'
+                              action='".Toolbox::getItemTypeFormURL("PluginOrderReception")."'>";
+               echo "<div id='massreception$orders_id$rand'></div>";
+               echo Html::scriptBlock("function viewmassreception".$orders_id."$rand() {".
+                                      Ajax::updateItemJsCode("massreception".$orders_id.$rand,
+                                                             $CFG_GLPI["root_doc"]."/plugins/order/ajax/massreception.php",
+                                                             [
+                                                                'plugin_order_orders_id'     => $orders_id,
+                                                                'plugin_order_references_id' => $references_id,
+                                                             ],
+                                                             false, false)."
+                  }");
+               echo "<p><a href='javascript:viewmassreception".$orders_id."$rand();'>";
+               echo __("Take item delivery (bulk)", "order")."</a></p><br>";
+               Html::closeForm();
+            }
+         }
       echo "</div>";
       echo "<br>";
    }


### PR DESCRIPTION
Re add old feature previously droped

On large order, add capability to define number of items to take delivery of, instead of selecting one by one.

![image](https://user-images.githubusercontent.com/7335054/169788886-c6050215-30d0-435c-a161-bb876aa8c955.png)
