### PR TITLE
fix(reception): drop 'transfer' action

### DIFF
--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -517,6 +517,10 @@ class PluginOrderReception extends CommonDBChild {
    function getSpecificMassiveActions($checkitem = null) {
       $isadmin = static::canUpdate();
       $actions = parent::getSpecificMassiveActions($checkitem);
+
+      //drop transfer action
+      unset($actions[MassiveAction::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list']);
+
       $sep     = __CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR;
 
       $actions[$sep.'reception'] = __("Take item delivery", "order");


### PR DESCRIPTION
```transfer``` action from reception tab is useless, ambigous et thrown an error

![image](https://user-images.githubusercontent.com/7335054/170059345-f8114a11-828d-4087-b8fc-2a3da15fe85e.png)


remove it


internal ref : !24076