### PR TITLE
fix(transfer): use own transfer action

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -336,6 +336,7 @@ class PluginOrderLink extends CommonDBChild {
                               ref.`id` AS id,
                               ref.`templates_id`,
                               items.`states_id`,
+                              items.`entities_id`,
                               items.`delivery_date`,
                               items.`delivery_number`,
                               ref.`name`,
@@ -416,6 +417,7 @@ class PluginOrderLink extends CommonDBChild {
          }
          echo "<th>" . __("Reference") . "</th>";
          echo "<th>" . __("Status") . "</th>";
+         echo "<th>" . __("Entity") . "</th>";
          echo "<th>" . __("Delivery date") . "</th>";
          echo "<th>" . _n("Associated item", "Associated items", 2) . "</th>";
          echo "<th>" . __("Serial number") . "</th></tr>";
@@ -447,6 +449,7 @@ class PluginOrderLink extends CommonDBChild {
                echo "<td align='center'>" . $PluginOrderReference->getReceptionReferenceLink($data) . "</td>";
             }
             echo "<td align='center'>" . $PluginOrderReception->getReceptionStatus($detailID) . "</td>";
+            echo "<td align='center'>" . Dropdown::getDropdownName(getTableForItemType(Entity::class), $data["entities_id"]) . "</td>";
             echo "<td align='center'>" . Html::convDate($data["delivery_date"]) . "</td>";
             echo "<td align='center'>" . $this->getReceptionItemName($data["items_id"], $data["itemtype"]);
             echo "<td align='center'>" . $this->getItemSerialNumber($data["items_id"], $data["itemtype"]) . "</td>";

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -528,7 +528,7 @@ class PluginOrderReception extends CommonDBChild {
 
       $actions[$sep.'reception'] = __("Take item delivery", "order");
       $actions[$sep.'transfer_order_item'] = "<i class='fa-fw fas fa-level-up-alt'></i>" .
-      _x('button', 'Add to transfer list');
+      _x('button', 'Transfer', 'order');
 
       return $actions;
    }
@@ -584,7 +584,7 @@ class PluginOrderReception extends CommonDBChild {
       $order = new PluginOrderOrder();
       $order->getFromDB($plugin_order_orders_id);
 
-      echo "<label class='order_ma'>".__("Desired Entity", "order") . "</label>";
+      echo "<label class='order_ma'>".__("Destination entity", "order") . "</label>";
       Entity::Dropdown([
          'name'        => "entities_id",
          'entity'      => $order->fields['entities_id'],

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -382,6 +382,7 @@ class PluginOrderReception extends CommonDBChild {
                              ref.`id` AS id,
                              ref.`templates_id`,
                              items.`states_id`,
+                             items.`entities_id`,
                              items.`comment`,
                              items.`plugin_order_deliverystates_id`,
                              items.`delivery_date`,
@@ -428,6 +429,7 @@ class PluginOrderReception extends CommonDBChild {
          }
          echo "<th>" . __("Reference") . "</th>";
          echo "<th>" . __("Status") . "</th>";
+         echo "<th>" . __("Entity") . "</th>";
          echo "<th>" . __("Delivery date") . "</th>";
          echo "<th>" . __("Delivery form") . "</th>";
          echo "<th>" . __("Delivery status", "order") . "</th>";
@@ -471,6 +473,8 @@ class PluginOrderReception extends CommonDBChild {
                echo "</a>";
             }
             echo "</td>";
+
+            echo "<td align='center'>" . Dropdown::getDropdownName(getTableForItemType(Entity::class), $data["entities_id"]) . "</td>";
             echo "<td align='center'>" . Html::convDate($data["delivery_date"]) . "</td>";
             echo "<td align='center'>" . $data["delivery_number"] . "</td>";
             echo "<td align='center'>" .
@@ -524,7 +528,7 @@ class PluginOrderReception extends CommonDBChild {
 
       $actions[$sep.'reception'] = __("Take item delivery", "order");
       $actions[$sep.'transfer_order_item'] = "<i class='fa-fw fas fa-level-up-alt'></i>" .
-      _x('button', 'Add to transfer list !');
+      _x('button', 'Add to transfer list');
 
       return $actions;
    }

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -522,7 +522,6 @@ class PluginOrderReception extends CommonDBChild {
       $isadmin = static::canUpdate();
       $actions = parent::getSpecificMassiveActions($checkitem);
 
-
       //remove native transfer action
       unset($actions[MassiveAction::class.MassiveAction::CLASS_ACTION_SEPARATOR.'add_transfer_list']);
       $sep     = __CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR;
@@ -586,10 +585,11 @@ class PluginOrderReception extends CommonDBChild {
       $order->getFromDB($plugin_order_orders_id);
 
       echo "<label class='order_ma'>".__("Desired Entity", "order") . "</label>";
-      Entity::Dropdown(['name' => "entities_id",
-                        'entity' => $order->fields['entities_id'],
-                        'entity_sons' => $order->fields['is_recursive']]
-                     );
+      Entity::Dropdown([
+         'name'        => "entities_id",
+         'entity'      => $order->fields['entities_id'],
+         'entity_sons' => $order->fields['is_recursive']
+      ]);
       echo "<br/><br/>";
    }
 

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -522,6 +522,7 @@ class PluginOrderReception extends CommonDBChild {
       $isadmin = static::canUpdate();
       $actions = parent::getSpecificMassiveActions($checkitem);
 
+
       //remove native transfer action
       unset($actions[MassiveAction::class.MassiveAction::CLASS_ACTION_SEPARATOR.'add_transfer_list']);
       $sep     = __CLASS__.MassiveAction::CLASS_ACTION_SEPARATOR;
@@ -580,8 +581,15 @@ class PluginOrderReception extends CommonDBChild {
 
 
    public function showTransferForm($params = []) {
+      $plugin_order_orders_id = $params['plugin_order_orders_id'];
+      $order = new PluginOrderOrder();
+      $order->getFromDB($plugin_order_orders_id);
+
       echo "<label class='order_ma'>".__("Desired Entity", "order") . "</label>";
-      Entity::Dropdown(['name' => "entities_id"]);
+      Entity::Dropdown(['name' => "entities_id",
+                        'entity' => $order->fields['entities_id'],
+                        'entity_sons' => $order->fields['is_recursive']]
+                     );
       echo "<br/><br/>";
    }
 


### PR DESCRIPTION
use own ```transfer``` action because :

- ```MassivecAction``` are link to ```PluginOrderReception``` object (not ```PluginOrderOrder_Item```) and compute ```PluginOrderReception``` table instead of ```PluginOrderOrder_Item``` table and thrown error

```
[2022-05-25 07:54:58] glpisqllog.ERROR: DBmysql::query() in /home/stanislas/Teclib/dev/GLPI/10.0-bugfixes/src/DBmysql.php line 370
  *** MySQL query error:
  SQL: SELECT `glpi_plugin_order_receptions`.`id`, `glpi_plugin_order_receptions`.`name`, `entities`.`completename` AS `locname`, `entities`.`id` AS `entID` FROM `glpi_plugin_order_receptions` LEFT JOIN `glpi_entities` AS `entities` ON (`entities`.`id` = `glpi_plugin_order_receptions`.`entities_id`) WHERE `glpi_plugin_order_receptions`.`id` IN ('1', '2') ORDER BY `locname`, `glpi_plugin_order_receptions`.`name`
  Error: Table '100bugfixes.glpi_plugin_order_receptions' doesn't exist
  Backtrace :
  src/DBmysqlIterator.php:110                        
  src/DBmysql.php:1048                               DBmysqlIterator->execute()
  src/Transfer.php:4145                              DBmysql->request()
  front/transfer.action.php:67                       Transfer->showTransferList()
  {"user":"2@stanislas-XPS-13-9343"} 
[2022-05-25 07:58:16] glpisqllog.ERROR: DBmysql::query() in /home/stanislas/Teclib/dev/GLPI/10.0-bugfixes/src/DBmysql.php line 370
```

- ```PluginOrderOrder_Item``` table does not have ```name``` column and thrown an error if wy try to use it

```
[2022-05-25 08:23:50] glpisqllog.ERROR: DBmysql::query() in /home/stanislas/Teclib/dev/GLPI/10.0-bugfixes/src/DBmysql.php line 370
  *** MySQL query error:
  SQL: SELECT `glpi_plugin_order_orders_items`.`id`, `glpi_plugin_order_orders_items`.`name`, `entities`.`completename` AS `locname`, `entities`.`id` AS `entID` FROM `glpi_plugin_order_orders_items` LEFT JOIN `glpi_entities` AS `entities` ON (`entities`.`id` = `glpi_plugin_order_orders_items`.`entities_id`) WHERE `glpi_plugin_order_orders_items`.`id` IN ('1', '2') ORDER BY `locname`, `glpi_plugin_order_orders_items`.`name`
  Error: Unknown column 'glpi_plugin_order_orders_items.name' in 'field list'
  Backtrace :
  src/DBmysqlIterator.php:110                        
  src/DBmysql.php:1048                               DBmysqlIterator->execute()
  src/Transfer.php:4145                              DBmysql->request()
  front/transfer.action.php:67                       Transfer->showTransferList()
```

So create own transfer method

Add Entity column from reception 
![image](https://user-images.githubusercontent.com/7335054/170199846-336ec4f2-cf76-4adb-bb11-34c85f4668e9.png)

and Associated items list
![image](https://user-images.githubusercontent.com/7335054/170199953-31840b7d-186e-4d3e-b6e3-166e07ffd9bd.png)

Internal ref : 24077 and 24076
