### PR TITLE
Fix auto generation for "reference free" items

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -55,8 +55,13 @@ class PluginOrderLink extends CommonDBChild {
    }
 
 
-   public static function getTypesThanCannotBeGenerated() {
-      return ['CartridgeItem', 'SoftwareLicense', 'Contract'];
+   public static function getTypesThanCannotBeGenerared() {
+      return [
+         'CartridgeItem',
+         'SoftwareLicense',
+         'Contract',
+         '', // Items without references show up as an empty itemtype
+      ];
    }
 
 


### PR DESCRIPTION
"Reference free" items (which is not a correct translation of "Référence libre" IMO) can be used to add items to orders without defining their itemtypes.

![image](https://user-images.githubusercontent.com/42734840/230589295-abf3da8a-daed-4319-99a5-b59e99783c68.png)
 
Since these items do not have an itemtype, we can't generate any GLPI items for them on delivery.
This mean on the "Associated items" tab, there is no checkbox to run massive actions for these items:

![image](https://user-images.githubusercontent.com/42734840/230589687-635368d0-5010-44d1-8586-597c908cfb15.png)

For comparison, here is another order with real item references, you can see the checkboxed are available in this case:

![image](https://user-images.githubusercontent.com/42734840/230589958-d19d427a-bf16-4558-8664-3c84b7530533.png)

So the TLDR is that reference free item cant be generated as the checkbox are not displayed (which is normal).
However, there is an option to enable auto generation on item delivery:

![image](https://user-images.githubusercontent.com/42734840/230590214-7f45425d-ec73-45f4-a8b0-fe8b46654a82.png)

With this option active, the plugin will try to generate all items when they are marked as "delivered", even if they are reference free.
This trigger an exception:
```
[2023-04-07 11:50:07] glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class name must be a valid object or a string in /home/aclai/localhost/glpi/10.0-bugfixes/plugins/order/inc/link.class.php at line 1042
  Backtrace :
  plugins/order/inc/reception.class.php:994          PluginOrderLink->generateNewItem()
  plugins/order/inc/reception.class.php:868          PluginOrderReception::generateAsset()
  plugins/order/inc/reception.class.php:599          PluginOrderReception->updateReceptionStatus()
  src/MassiveAction.php:1408                         PluginOrderReception::processMassiveActionsForOneItemtype()
  src/MassiveAction.php:1386                         MassiveAction->processForSeveralItemtypes()
  front/massiveaction.php:59                         MassiveAction->process()
```

To fix this, I've blacklisted empty itemtypes (which reference free item use as their value) from item generations.