### PR TITLE
fix(core): fix invalid relation declared

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -198,7 +198,7 @@ function plugin_order_getDatabaseRelations() {
             "glpi_plugin_order_orders" => "budgets_id"
          ],
          "glpi_plugin_order_othertypes" => [
-            "glpi_plugin_order_others" => "othertypes_id"
+            "glpi_plugin_order_others" => "plugin_order_othertypes_id"
          ],
          "glpi_suppliers" => [
             "glpi_plugin_order_orders"               => "suppliers_id",

--- a/inc/other.class.php
+++ b/inc/other.class.php
@@ -58,13 +58,16 @@ class PluginOrderOther extends CommonDBTM {
                   `id` int {$default_key_sign} NOT NULL auto_increment,
                   `entities_id` int {$default_key_sign} NOT NULL default '0',
                   `name` varchar(255) default NULL,
-                  `othertypes_id` int {$default_key_sign} NOT NULL default '0',
+                  `plugin_order_othertypes_id` int {$default_key_sign} NOT NULL default '0',
                   PRIMARY KEY  (`ID`),
                   KEY `name` (`name`),
                   KEY `entities_id` (`entities_id`),
-                  KEY `othertypes_id` (`othertypes_id`)
+                  KEY `plugin_order_othertypes_id` (`plugin_order_othertypes_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
          $DB->query($query) or die ($DB->error());
+      } else {
+         $migration->displayMessage("Rename 'othertypes_id' to 'plugin_order_othertypes_id'");
+         $migration->changeField($table, "othertypes_id", "plugin_order_othertypes_id", "int {$default_key_sign} NOT NULL default '0'");
       }
    }
 


### PR DESCRIPTION
Fix error from ```Invalid relations declared```
```
[2023-05-02 07:34:32] glpiphplog.WARNING:   *** PHP User Warning (512): Invalid relations declared between "glpi_plugin_order_othertypes" and "glpi_plugin_order_others" table. Target field "othertypes_id" is not a foreign key field. in /var/www/html/GLPI/src/DbUtils.php at line 2144
  Backtrace :
  src/DbUtils.php:2144                               trigger_error()
  inc/db.function.php:585                            DbUtils->getDbRelations()
  src/CommonDBTM.php:866                             getDbRelations()
  src/CommonDBTM.php:788                             CommonDBTM->cleanRelationData()
  src/CommonDBTM.php:2064                            CommonDBTM->deleteFromDB()
  src/RuleMatchedLog.php:183                         CommonDBTM->delete()
```

Internal ref : 27839