### PR TITLE
Fix invalid foreign key name

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -198,7 +198,7 @@ function plugin_order_getDatabaseRelations() {
             "glpi_plugin_order_orders" => "budgets_id"
          ],
          "glpi_plugin_order_othertypes" => [
-            "glpi_plugin_order_others" => "othertypes_id"
+            "glpi_plugin_order_others" => "plugin_order_othertypes_id"
          ],
          "glpi_suppliers" => [
             "glpi_plugin_order_orders"               => "suppliers_id",

--- a/inc/other.class.php
+++ b/inc/other.class.php
@@ -58,13 +58,15 @@ class PluginOrderOther extends CommonDBTM {
                   `id` int {$default_key_sign} NOT NULL auto_increment,
                   `entities_id` int {$default_key_sign} NOT NULL default '0',
                   `name` varchar(255) default NULL,
-                  `othertypes_id` int {$default_key_sign} NOT NULL default '0',
+                  `plugin_order_othertypes_id` int {$default_key_sign} NOT NULL default '0',
                   PRIMARY KEY  (`ID`),
                   KEY `name` (`name`),
                   KEY `entities_id` (`entities_id`),
-                  KEY `othertypes_id` (`othertypes_id`)
+                  KEY `plugin_order_othertypes_id` (`plugin_order_othertypes_id`)
                ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
          $DB->query($query) or die ($DB->error());
+      } else {
+          $migration->changeField('glpi_plugin_order_others', 'othertypes_id', 'plugin_order_othertypes_id', "int {$default_key_sign} NOT NULL default '0'");
       }
    }
 


### PR DESCRIPTION
I do not see any usage of it, but the bad naming was triggering a warning.