### PR TITLE
fix: check mendatory fields

### DIFF
--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -764,9 +764,11 @@ class PluginOrderOrder extends CommonDBTM {
       }
 
       $config = PluginOrderConfig::getConfig();
-      if ($config->isAccountSectionDisplayed()
-         && $config->isAccountSectionMandatory()
-         && $input["plugin_order_accountsections_id"] ?? $this->fields["plugin_order_accountsections_id"] == 0) {
+      if (
+          $config->isAccountSectionDisplayed()
+          && $config->isAccountSectionMandatory()
+          && ($input["plugin_order_accountsections_id"] ?? $this->fields["plugin_order_accountsections_id"]) == 0
+      ) {
          Session::addMessageAfterRedirect(__("An account section is mandatory !", "order"), false, ERROR);
          return [];
       }

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -764,7 +764,9 @@ class PluginOrderOrder extends CommonDBTM {
       }
 
       $config = PluginOrderConfig::getConfig();
-      if ($config->isAccountSectionDisplayed() && $config->isAccountSectionMandatory() && $input["plugin_order_accountsections_id"] == 0) {
+      if ($config->isAccountSectionDisplayed()
+         && $config->isAccountSectionMandatory()
+         && $input["plugin_order_accountsections_id"] ?? $this->fields["plugin_order_accountsections_id"] == 0) {
          Session::addMessageAfterRedirect(__("An account section is mandatory !", "order"), false, ERROR);
          return [];
       }

--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -609,9 +609,11 @@ class PluginOrderOrder_Item extends CommonDBRelation {
 
    public function prepareInputForUpdate($input) {
       $config = PluginOrderConfig::getConfig();
-      if ($config->isAnalyticNatureDisplayed()
+      if (
+          $config->isAnalyticNatureDisplayed()
           && $config->isAnalyticNatureMandatory()
-          && $input["plugin_order_analyticnatures_id"] ?? $this->fields["plugin_order_analyticnatures_id"] == 0) {
+          && ($input["plugin_order_analyticnatures_id"] ?? $this->fields["plugin_order_analyticnatures_id"]) == 0
+      ) {
          Session::addMessageAfterRedirect(__("An analytic nature is mandatory !", "order"), false, ERROR);
          return [];
       }

--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -611,7 +611,7 @@ class PluginOrderOrder_Item extends CommonDBRelation {
       $config = PluginOrderConfig::getConfig();
       if ($config->isAnalyticNatureDisplayed()
           && $config->isAnalyticNatureMandatory()
-          && $input["plugin_order_analyticnatures_id"] == 0) {
+          && $input["plugin_order_analyticnatures_id"] ?? $this->fields["plugin_order_analyticnatures_id"] == 0) {
          Session::addMessageAfterRedirect(__("An analytic nature is mandatory !", "order"), false, ERROR);
          return [];
       }


### PR DESCRIPTION
The mandatory fields check blocked modifications when these fields had been entered beforehand.

What's more, it was marked as validated but nothing was recorded :

![image_paste](https://github.com/pluginsGLPI/order/assets/8530352/06ca36a7-91ef-4ab4-b758-3cdedaa0e7d8)



ref. : !30784