### PR TITLE
fix: restores the ability to clone an order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Restores the ability to clone an order
+
+
 ## [1.9.6] - 2017-03-03
 
 **Compatible with GLPI 0.85 and above**

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -34,6 +34,8 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginOrderOrder extends CommonDBTM {
 
+   use Glpi\Features\Clonable;
+
    public static $rightname         = 'plugin_order_order';
 
    public $is_template              = true;
@@ -72,6 +74,12 @@ class PluginOrderOrder extends CommonDBTM {
    const RIGHT_GENERATEODT                      = 4096;
    const RIGHT_DELIVERY                         = 8192;
    const ALLRIGHTS                              = 16255;
+
+
+   public function getCloneRelations(): array
+   {
+      return [];
+   }
 
 
    public static function getTypeName($nb = 0) {


### PR DESCRIPTION
Since GLPI 10.0, it was no longer possible to clone an order.

!31772