### PR TITLE
fix migration update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+
+### Changed
+
+- Fix error message during plugin update
+
+
 ## [2.10.5] - 2024-02-23
 
 ### Changed

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -2549,8 +2549,10 @@ class PluginOrderOrder extends CommonDBTM
 
            //1.2.0
             $domigration_itemtypes = false;
-            $migration->renameTable("glpi_plugin_order", $table);
-            $domigration_itemtypes = true;
+            if ($DB->tableExists('glpi_plugin_order')) {
+                $migration->renameTable("glpi_plugin_order", $table);
+                $domigration_itemtypes = true;
+            }
 
             $migration->changeField($table, "ID", "id", "int {$default_key_sign} NOT NULL AUTO_INCREMENT");
             $migration->changeField(


### PR DESCRIPTION
ref !31826

Fix error message during plugin update (since https://github.com/pluginsGLPI/order/pull/372) :

```
SQL Error "1062": Duplicate entry '0-PluginOrderOrder-1' for key 'unicity' in query "UPDATE `glpi_displaypreferences` SET `itemtype` = 'PluginOrderOrder' WHERE `itemtype` = '3150'"
In DBmysql.php line 1535:
update itemtype of table glpi_displaypreferences for PluginOrderOrder - Erreur durant l'éxecution de la requête : UPDATE `glpi_displaypreferences` SET `itemtype` = 'PluginOrderOrder' WHERE `itemtype` = '3150' - L'erreur est Duplicate entry '0-PluginOrderOrder-1' for key 'unicity'
```