### PR TITLE
fix: Paid invoice changes status to Paid

### DIFF
--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -2145,14 +2145,18 @@ class PluginOrderOrder extends CommonDBTM
 
         $order = new self();
         $order->getFromDB($ID);
+        $conf = PluginOrderConfig::getConfig();
         if ($all_paid) {
-            $state = PluginOrderBillState::PAID;
+            $bill_state = PluginOrderBillState::PAID;
+            $order_status = $conf->fields['order_status_paid'];
         } else {
-            $state = PluginOrderBillState::NOTPAID;
+            $bill_state = PluginOrderBillState::NOTPAID;
+            $order_status = $order->fields['plugin_order_orderstates_id'];
         }
         $order->update([
             'id'                         => $ID,
-            'plugin_order_billstates_id' => $state
+            'plugin_order_billstates_id' => $bill_state,
+            'plugin_order_orderstates_id' => $order_status
         ]);
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Description

- It fixes !35687
Once all items on the invoice have been paid, the status of the order changes to "Paid"

