### PR TITLE
Fix - Can validate without attaching elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- Allow validation without elements attached to the order
+
 ## [2.10.6] - 2024-03-08
 
 ### Changed

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -1579,61 +1579,56 @@ class PluginOrderOrder extends CommonDBTM
          __("Validation process", "order") . "</th></tr>";
 
         if ($this->can($orders_id, READ) && $this->canDisplayValidationForm($orders_id)) {
-            if ($this->checkIfDetailExists($orders_id)) {
-                echo "<tr class='tab_bg_1'>";
-                echo "<td valign='top' align='right'>";
-                echo __("Comments") . ":&nbsp;";
-                echo "</td>";
-                echo "<td valign='top' align='left'>";
-                echo "<textarea cols='40' rows='4' name='comment'></textarea>";
-                echo "</td>";
+            echo "<tr class='tab_bg_1'>";
+            echo "<td valign='top' align='right'>";
+            echo __("Comments") . ":&nbsp;";
+            echo "</td>";
+            echo "<td valign='top' align='left'>";
+            echo "<textarea cols='40' rows='4' name='comment'></textarea>";
+            echo "</td>";
 
-                echo "<td align='center'>";
-                echo Html::hidden('id', ['value' => $orders_id]);
+            echo "<td align='center'>";
+            echo Html::hidden('id', ['value' => $orders_id]);
 
-                $link = "";
+            $link = "";
 
-                if ($this->canCancelOrder()) {
-                    echo "<input type='submit' onclick=\"return confirm('"
-                    . __("Do you really want to cancel this order ? This option is irreversible !", "order")
-                    . "')\" name='cancel_order' value=\"" . __("Cancel order", "order") . "\" class='submit'>";
-                    $link = "<br><br>";
-                }
-
-                if ($this->canValidateOrder()) {
-                    echo $link . "<input type='submit' name='validate' value=\""
-                    . __("Validate order", "order") . "\" class='submit'>";
-                    $link = "<br><br>";
-                }
-
-                if ($this->canCancelValidationRequest()) {
-                    echo $link . "<input type='submit' onclick=\"return confirm('"
-                    . __("Do you want to cancel the validation approval ?", "order")
-                    . "')\" name='cancel_waiting_for_approval' value=\""
-                    . __("Cancel ask for validation", "order") . "\" class='submit'>";
-                    $link = "<br><br>";
-                }
-
-                if ($this->canDoValidationRequest()) {
-                    echo $link . "<input type='submit' name='waiting_for_approval' value=\""
-                    . __("Ask for validation", "order") . "\" class='submit'>";
-                    $link = "<br><br>";
-                }
-
-                if ($this->canUndoValidation()) {
-                    echo $link . "<input type='submit' onclick=\"return confirm('"
-                    . __("Do you really want to edit the order ?", "order")
-                    . "')\" name='undovalidation' value=\""
-                    . __("Edit order", "order") . "\" class='submit'>";
-                    $link = "<br><br>";
-                }
-
-                echo "</td>";
-                echo "</tr>";
-            } else {
-                echo "<tr class='tab_bg_2 center'><td>"
-                . __("Thanks to add at least one equipment on your order.", "order") . "</td></tr>";
+            if ($this->canCancelOrder()) {
+                echo "<input type='submit' onclick=\"return confirm('"
+                . __("Do you really want to cancel this order ? This option is irreversible !", "order")
+                . "')\" name='cancel_order' value=\"" . __("Cancel order", "order") . "\" class='submit'>";
+                $link = "<br><br>";
             }
+
+            if ($this->canValidateOrder()) {
+                echo $link . "<input type='submit' name='validate' value=\""
+                . __("Validate order", "order") . "\" class='submit'>";
+                $link = "<br><br>";
+            }
+
+            if ($this->canCancelValidationRequest()) {
+                echo $link . "<input type='submit' onclick=\"return confirm('"
+                . __("Do you want to cancel the validation approval ?", "order")
+                . "')\" name='cancel_waiting_for_approval' value=\""
+                . __("Cancel ask for validation", "order") . "\" class='submit'>";
+                $link = "<br><br>";
+            }
+
+            if ($this->canDoValidationRequest()) {
+                echo $link . "<input type='submit' name='waiting_for_approval' value=\""
+                . __("Ask for validation", "order") . "\" class='submit'>";
+                $link = "<br><br>";
+            }
+
+            if ($this->canUndoValidation()) {
+                echo $link . "<input type='submit' onclick=\"return confirm('"
+                . __("Do you really want to edit the order ?", "order")
+                . "')\" name='undovalidation' value=\""
+                . __("Edit order", "order") . "\" class='submit'>";
+                $link = "<br><br>";
+            }
+
+            echo "</td>";
+            echo "</tr>";
         }
         echo "</table></div>";
         Html::closeForm();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36683
- Here is a brief description of what this PR does

It is currently impossible to validate an order that has no elements attached to it, because the validation tab looks like this when no elements are attached to the order

## Screenshots (if appropriate):

Before : 
![image](https://github.com/user-attachments/assets/6379fef3-0930-4f17-aa49-3c306c5a8a9d)

After : 
![image](https://github.com/user-attachments/assets/9b9f36cb-d0da-4810-81d5-3501233e53bc)

