### PR TITLE
fix: The calculation of the total price of the orders remained always at 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+- Fix: The calculation of the total price of the orders remained always at 0
+
 ## [2.10.6] - 2024-03-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Fix: The calculation of the total price of the orders remained always at 0
+- Fixed the cumulative total order price (TTC) calculation in budgets.
 
 ## [2.10.6] - 2024-03-08
 

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -2049,7 +2049,7 @@ class PluginOrderOrder extends CommonDBTM
 
                 //if state is cancel do not decremente total already use
                 if ($data['plugin_order_orderstates_id'] !== PluginOrderOrderState::CANCELED) {
-                     $total += $prices["priceTTC"];
+                     $total += $prices["priceHT"];
                 }
                 $link   = Toolbox::getItemTypeFormURL(__CLASS__);
 

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -2048,7 +2048,7 @@ class PluginOrderOrder extends CommonDBTM
                 );
 
                 //if state is cancel do not decremente total already use
-                if (!in_array($data['plugin_order_orderstates_id'], [PluginOrderOrderState::CANCELED, PluginOrderOrderState::DRAFT, PluginOrderOrderState::WAITING_FOR_APPROVAL])) {
+                if ($data['plugin_order_orderstates_id'] !== PluginOrderOrderState::CANCELED) {
                      $total += $prices["priceTTC"];
                 }
                 $link   = Toolbox::getItemTypeFormURL(__CLASS__);

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -2048,8 +2048,8 @@ class PluginOrderOrder extends CommonDBTM
                 );
 
                 //if state is cancel do not decremente total already use
-                if ($data['plugin_order_orderstates_id'] < 5) {
-                     $total += $prices["priceHT"];
+                if (!in_array($data['plugin_order_orderstates_id'], [PluginOrderOrderState::CANCELED, PluginOrderOrderState::DRAFT, PluginOrderOrderState::WAITING_FOR_APPROVAL])) {
+                     $total += $prices["priceTTC"];
                 }
                 $link   = Toolbox::getItemTypeFormURL(__CLASS__);
 


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36770
- The calculation of the total price of an order remains at 0 regardless of the status of the orders. For this calculation, only cancelled orders must not be price in the total calculation.

![Capture d’écran du 2025-03-12 09-40-15](https://github.com/user-attachments/assets/5b697930-7b39-4756-97fb-55ae986b4d58)
