### PR TITLE
Fix(UI): no icon from massiveaction (only for single action)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix icon for `transfer` action
+
 ## [2.11.1] - 2025-07-11
 
 ### Fixed

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -730,8 +730,7 @@ class PluginOrderReception extends CommonDBChild
         $sep     = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR;
 
         $actions[$sep . 'reception'] = __("Take item delivery", "order");
-        $actions[$sep . 'transfer_order_item'] = "<i class='fa-fw fas fa-level-up-alt'></i>" .
-        _x('button', 'Transfer', 'order');
+        $actions[$sep . 'transfer_order_item'] = _x('button', 'Add to transfer list');
 
         return $actions;
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !35240

Remove icon from massive action

Icon are only allowed from single action

<img width="1109" height="394" alt="image" src="https://github.com/user-attachments/assets/387d69e0-23e5-4d0e-9b2e-d6aa247079d3" />


## Screenshots (if appropriate):
