### PR TITLE
fix(reference): prevent empty string in ecotax_price by setting a default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Fix icon for `transfer` action
+- Fix reference form error when ecotax_price field is not set
 
 ## [2.11.1] - 2025-07-11
 

--- a/inc/reference.class.php
+++ b/inc/reference.class.php
@@ -325,6 +325,10 @@ class PluginOrderReference extends CommonDBTM
             return false;
         }
 
+        if (!isset($input["ecotax_price"]) || $input["ecotax_price"] == '') {
+            $input["ecotax_price"] = 0;
+        }
+
         return $input;
     }
 

--- a/inc/reference.class.php
+++ b/inc/reference.class.php
@@ -734,15 +734,8 @@ class PluginOrderReference extends CommonDBTM
 
         echo "<tr class='tab_bg_1'><td>" . __("Eco-responsibility fees") . "</td>";
         echo "<td>";
-        echo Html::input(
-            'ecotax_price',
-            [
-                'type'  => 'number',
-                'step'  => PLUGIN_ORDER_NUMBER_STEP,
-                'min'   => 0,
-                'value' => $this->fields['ecotax_price'],
-            ]
-        );
+        echo "<input type='number' class='form-control' min='0' step='" . PLUGIN_ORDER_NUMBER_STEP . "' name='ecotax_price' size='5'"
+            . " value=\"" . Html::formatNumber($this->fields["ecotax_price"], true) . "\">";
         echo "</td>";
         echo "<td colspan='2'></td></tr>";
 


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- If the ecotax_price field is empty when submitting the form to add or modify a product reference, the action is blocked and an error is recorded in the sql_errors.log file.

## Screenshots (if appropriate):
<img width="536" height="55" alt="image" src="https://github.com/user-attachments/assets/73a84340-05ab-44f0-971b-3ad18b71c271" />
<img width="1043" height="222" alt="image" src="https://github.com/user-attachments/assets/5e79fc00-a9a8-4049-9b78-74b95cc98ec3" />


