### PR TITLE
fix(order-item): incorrect values shown when expanding all table rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix icon for `transfer` action
 - Fix reference form error when ecotax_price field is not set
+- Fix expanding all rows in table shows incorrect reference
 
 ## [2.11.1] - 2025-07-11
 

--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -1137,9 +1137,16 @@ class PluginOrderOrder_Item extends CommonDBRelation // phpcs:ignore
                 "$table.plugin_order_ordertaxes_id",
                 "$table.price_ati"
             ],
-            'FROM' => [$table, $table_ref],
+            'FROM' => $table,
+            'LEFT JOIN' => [
+                $table_ref => [
+                    'ON' => [
+                        "$table.plugin_order_references_id",
+                        "$table_ref.id",
+                    ],
+                ],
+            ],
             'WHERE' => [
-                "$table.plugin_order_references_id" => "$table_ref.id",
                 "$table.plugin_order_references_id" => $refID,
                 "$table.price_taxfree" => ['LIKE', $price_taxfree],
                 "$table.discount" => ['LIKE', $discount],

--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -1106,7 +1106,15 @@ class PluginOrderOrder_Item extends CommonDBRelation // phpcs:ignore
 
         $criteria_count = [
             'COUNT' => 'total',
-            'FROM' => [$table, $table_ref],
+            'FROM' => $table,
+            'JOIN' => [
+                $table_ref => [
+                    'ON' => [
+                        "$table.plugin_order_references_id",
+                        "$table_ref.id",
+                    ],
+                ],
+            ],
             'WHERE' => [
                 "$table.plugin_order_references_id" => "$table_ref.id",
                 "$table.plugin_order_references_id" => $refID,
@@ -1138,7 +1146,7 @@ class PluginOrderOrder_Item extends CommonDBRelation // phpcs:ignore
                 "$table.price_ati"
             ],
             'FROM' => $table,
-            'LEFT JOIN' => [
+            'JOIN' => [
                 $table_ref => [
                     'ON' => [
                         "$table.plugin_order_references_id",


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38760
- The table that was supposed to display more details about the ordered reference did not display the correct reference.

## Screenshots (if appropriate):

Before
<img width="1576" height="510" alt="image" src="https://github.com/user-attachments/assets/a5dce80e-ee38-4a08-9d4d-4d88b7bde602" />

After
<img width="1578" height="334" alt="image" src="https://github.com/user-attachments/assets/71ff1838-9ca2-497d-a6cb-6788ec0c3673" />

