### PR TITLE
Fix(Core): fix uninstall method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix `Validation` tab from `Order`
 - Fix invalid relations declared
-
+- Fix uninstall method
 
 ## [2.12.4] - 2025-12-02
 

--- a/inc/notificationtargetorder.class.php
+++ b/inc/notificationtargetorder.class.php
@@ -469,11 +469,6 @@ class PluginOrderNotificationTargetOrder extends NotificationTarget
         $template->deleteByCriteria([
             'itemtype' => 'PluginOrderOrder',
         ]);
-
-        $translation = new NotificationTemplateTranslation();
-        $translation->deleteByCriteria([
-            'itemtype' => 'PluginOrderOrder',
-        ]);
     }
 
 

--- a/inc/order_item.class.php
+++ b/inc/order_item.class.php
@@ -2301,11 +2301,6 @@ class PluginOrderOrder_Item extends CommonDBRelation // phpcs:ignore
         $template->deleteByCriteria([
             'itemtype' => 'PluginOrderOrder_Item',
         ]);
-
-        $translation = new NotificationTemplateTranslation();
-        $translation->deleteByCriteria([
-            'itemtype' => 'PluginOrderOrder_Item',
-        ]);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It maybe fixes #511 (but i can reproduce on my side)

Fix

```
[2025-12-19 09:19:10] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "MySQL query error: Unknown column 'itemtype' in 'where clause' (1054) in SQL query "SELECT `glpi_notificationtemplatetranslations`.`id` FROM `glpi_notificationtemplatetranslations` WHERE `itemtype` = 'PluginOrderOrder'"." at DBmysql.php line 398
  Backtrace :
  ./src/DBmysql.php:398                              
  ./src/DBmysqlIterator.php:126                      DBmysql->doQuery()
  ./src/DBmysql.php:1067                             DBmysqlIterator->execute()
  ./src/CommonDBTM.php:4704                          DBmysql->request()
  ...order/inc/notificationtargetorder.class.php:474 CommonDBTM->deleteByCriteria()
  ./plugins/order/hook.php:134                       PluginOrderNotificationTargetOrder::uninstall()
  ./src/Plugin.php:1143                              plugin_order_uninstall()
  ./front/plugin.form.php:60                         Plugin->uninstall()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()

[2025-12-19 09:20:03] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "MySQL query error: Unknown column 'itemtype' in 'where clause' (1054) in SQL query "SELECT `glpi_notificationtemplatetranslations`.`id` FROM `glpi_notificationtemplatetranslations` WHERE `itemtype` = 'PluginOrderOrder'"." at DBmysql.php line 398
  Backtrace :
  ./src/DBmysql.php:398                              
  ./src/DBmysqlIterator.php:126                      DBmysql->doQuery()
  ./src/DBmysql.php:1067                             DBmysqlIterator->execute()
  ./src/CommonDBTM.php:4704                          DBmysql->request()
  ...order/inc/notificationtargetorder.class.php:474 CommonDBTM->deleteByCriteria()
  ./plugins/order/hook.php:134                       PluginOrderNotificationTargetOrder::uninstall()
  ./src/Plugin.php:1143                              plugin_order_uninstall()
  ./front/plugin.form.php:60                         Plugin->uninstall()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()

```
`itemtype` column not exist and 

`NotificationTemplateTranslation` is automatically purge by GLPI when `NotificationTemplate` is purge  (see `NotificationTemplate->cleanDBonPurge()`


## Screenshots (if appropriate):
