### PR TITLE
Fix(UI): correctly diplay Validation tab from Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- Fix `Validation` tab from `Order`
+
 ## [2.12.4] - 2025-12-02
 
 ### Fixed

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -641,7 +641,7 @@ class PluginOrderOrder extends CommonDBTM
                     self::RIGHT_UNDO_VALIDATION,
                 ])
             ) {
-                return self::createTabEntry(
+                $ong[1] = self::createTabEntry(
                     __s("Validation", "order"),
                     0,
                     null,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #520

correctly diplay `Validation` tab from `Order`

## Screenshots (if appropriate):
