### PR TITLE
Register active custom asset definitions as orderable itemtypes (GLPI 11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 ### Added
-- Add an `Orderable` capacity for GLPI 11 custom asset definitions, allowing each definition to opt-in to being used as a Product reference itemtype. Asset classes are filtered by per-user read permission.
+- Add an `Orderable` capacity for GLPI 11 custom asset definitions, allowing each definition to opt-in to being used as a Product reference itemtype. Asset classes are filtered by per-user read permission. Disabling the capacity on a definition cleans up its order line items and product references.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+### Added
+- Add an `Orderable` capacity for GLPI 11 custom asset definitions, allowing each definition to opt-in to being used as a Product reference itemtype. Asset classes are filtered by per-user read permission.
+
 ### Fixed
 
 - Fix generate associated item massive action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 ### Added
-- Add an `Orderable` capacity for GLPI 11 custom asset definitions, allowing each definition to opt-in to being used as a Product reference itemtype. Asset classes are filtered by per-user read permission. Disabling the capacity on a definition cleans up its order line items and product references.
+- Add an `Orderable` capacity for GLPI 11 custom asset definitions.
 
 ### Fixed
 

--- a/inc/orderablecapacity.class.php
+++ b/inc/orderablecapacity.class.php
@@ -1,13 +1,44 @@
 <?php
 
 /**
+ * -------------------------------------------------------------------------
+ * Order plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Order.
+ *
+ * Order is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Order is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Order. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2009-2023 by Order plugin team.
+ * @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/pluginsGLPI/order
+ * -------------------------------------------------------------------------
+ */
+
+use Glpi\Asset\Capacity\AbstractCapacity;
+use Glpi\Asset\CapacityConfig;
+
+/**
  * Capacity that flags a GLPI 11 custom asset definition as orderable
  * through the Order plugin. When enabled on an asset definition (Setup ->
  * Asset definitions -> {your asset} -> Capacities), the corresponding
  * generated asset class is appended to $ORDER_TYPES and becomes selectable
  * as an Item type when creating a Product reference.
  */
-class PluginOrderOrderableCapacity extends \Glpi\Asset\Capacity\AbstractCapacity
+class PluginOrderOrderableCapacity extends AbstractCapacity
 {
     public function getLabel(): string
     {
@@ -24,7 +55,7 @@ class PluginOrderOrderableCapacity extends \Glpi\Asset\Capacity\AbstractCapacity
         return __(
             'Allow this asset to be referenced as a Product reference and '
             . 'generated from the Generate item massive action.',
-            'order'
+            'order',
         );
     }
 
@@ -33,40 +64,40 @@ class PluginOrderOrderableCapacity extends \Glpi\Asset\Capacity\AbstractCapacity
         $count = 0;
         if (class_exists('PluginOrderReference')) {
             $count = countElementsInTable(
-                \PluginOrderReference::getTable(),
-                ['itemtype' => $classname]
+                PluginOrderReference::getTable(),
+                ['itemtype' => $classname],
             );
         }
+
         return sprintf(
             _n('Used by %d order reference', 'Used by %d order references', $count, 'order'),
-            $count
+            $count,
         );
     }
 
     /**
      * Clean up plugin data linked to the asset class when the capacity is
-     * disabled on its definition: remove Product references targeting the
-     * class and order line items that link orders to instances of the class.
+     * disabled on its definition: remove order line items first (parent
+     * Product references refuse deletion via pre_deleteItem() while still
+     * referenced by orders_items), then remove the references themselves.
      * Free-form references are intentionally left untouched, as they are
      * standalone records that do not reference any itemtype.
      */
-    public function onCapacityDisabled(string $classname, \Glpi\Asset\CapacityConfig $config): void
+    public function onCapacityDisabled(string $classname, CapacityConfig $config): void
     {
-        // Delete order line items first: PluginOrderReference::pre_deleteItem()
-        // refuses deletion while references are still in use by orders_items,
-        // so child records must be removed before parent references.
         if (class_exists('PluginOrderOrder_Item')) {
-            (new \PluginOrderOrder_Item())->deleteByCriteria(
+            (new PluginOrderOrder_Item())->deleteByCriteria(
                 ['itemtype' => $classname],
                 force: true,
-                history: false
+                history: false,
             );
         }
+
         if (class_exists('PluginOrderReference')) {
-            (new \PluginOrderReference())->deleteByCriteria(
+            (new PluginOrderReference())->deleteByCriteria(
                 ['itemtype' => $classname],
                 force: true,
-                history: false
+                history: false,
             );
         }
     }

--- a/inc/orderablecapacity.class.php
+++ b/inc/orderablecapacity.class.php
@@ -42,4 +42,32 @@ class PluginOrderOrderableCapacity extends \Glpi\Asset\Capacity\AbstractCapacity
             $count
         );
     }
+
+    /**
+     * Clean up plugin data linked to the asset class when the capacity is
+     * disabled on its definition: remove Product references targeting the
+     * class and order line items that link orders to instances of the class.
+     * Free-form references are intentionally left untouched, as they are
+     * standalone records that do not reference any itemtype.
+     */
+    public function onCapacityDisabled(string $classname, \Glpi\Asset\CapacityConfig $config): void
+    {
+        // Delete order line items first: PluginOrderReference::pre_deleteItem()
+        // refuses deletion while references are still in use by orders_items,
+        // so child records must be removed before parent references.
+        if (class_exists('PluginOrderOrder_Item')) {
+            (new \PluginOrderOrder_Item())->deleteByCriteria(
+                ['itemtype' => $classname],
+                force: true,
+                history: false
+            );
+        }
+        if (class_exists('PluginOrderReference')) {
+            (new \PluginOrderReference())->deleteByCriteria(
+                ['itemtype' => $classname],
+                force: true,
+                history: false
+            );
+        }
+    }
 }

--- a/inc/orderablecapacity.class.php
+++ b/inc/orderablecapacity.class.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Capacity that flags a GLPI 11 custom asset definition as orderable
+ * through the Order plugin. When enabled on an asset definition (Setup ->
+ * Asset definitions -> {your asset} -> Capacities), the corresponding
+ * generated asset class is appended to $ORDER_TYPES and becomes selectable
+ * as an Item type when creating a Product reference.
+ */
+class PluginOrderOrderableCapacity extends \Glpi\Asset\Capacity\AbstractCapacity
+{
+    public function getLabel(): string
+    {
+        return __('Orderable', 'order');
+    }
+
+    public function getIcon(): string
+    {
+        return 'ti ti-shopping-cart';
+    }
+
+    public function getDescription(): string
+    {
+        return __(
+            'Allow this asset to be referenced as a Product reference and '
+            . 'generated from the Generate item massive action.',
+            'order'
+        );
+    }
+
+    public function getCapacityUsageDescription(string $classname): string
+    {
+        $count = 0;
+        if (class_exists('PluginOrderReference')) {
+            $count = countElementsInTable(
+                \PluginOrderReference::getTable(),
+                ['itemtype' => $classname]
+            );
+        }
+        return sprintf(
+            _n('Used by %d order reference', 'Used by %d order references', $count, 'order'),
+            $count
+        );
+    }
+}

--- a/setup.php
+++ b/setup.php
@@ -125,6 +125,29 @@ function plugin_init_order()
             'Pdu',
         ];
 
+
+        // Register the Orderable capacity for GLPI 11 custom assets and append
+        // any custom asset class that has it enabled to $ORDER_TYPES, provided
+        // the current user is allowed to view it.
+        if (class_exists(\Glpi\Asset\AssetDefinitionManager::class)) {
+            $asset_manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
+            $orderable_capacity = new PluginOrderOrderableCapacity();
+            $asset_manager->registerCapacity($orderable_capacity);
+            $asset_manager->bootDefinitions();
+            foreach ($asset_manager->getDefinitions(true) as $definition) {
+                if (!$definition->hasCapacityEnabled($orderable_capacity)) {
+                    continue;
+                }
+                $custom_asset_class = $definition->getAssetClassName();
+                if (
+                    !in_array($custom_asset_class, $ORDER_TYPES, true)
+                    && $custom_asset_class::canView()
+                ) {
+                    $ORDER_TYPES[] = $custom_asset_class;
+                }
+            }
+        }
+
         $CFG_GLPI['plugin_order_types'] = $ORDER_TYPES;
 
         $PLUGIN_HOOKS['pre_item_purge']['order'] = [

--- a/setup.php
+++ b/setup.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+use Glpi\Asset\AssetDefinitionManager;
+
 use function Safe\define;
 
 define('PLUGIN_ORDER_VERSION', '2.12.6');
@@ -129,8 +131,8 @@ function plugin_init_order()
         // Register the Orderable capacity for GLPI 11 custom assets and append
         // any custom asset class that has it enabled to $ORDER_TYPES, provided
         // the current user is allowed to view it.
-        if (class_exists(\Glpi\Asset\AssetDefinitionManager::class)) {
-            $asset_manager = \Glpi\Asset\AssetDefinitionManager::getInstance();
+        if (class_exists(AssetDefinitionManager::class)) {
+            $asset_manager = AssetDefinitionManager::getInstance();
             $orderable_capacity = new PluginOrderOrderableCapacity();
             $asset_manager->registerCapacity($orderable_capacity);
             $asset_manager->bootDefinitions();
@@ -138,6 +140,7 @@ function plugin_init_order()
                 if (!$definition->hasCapacityEnabled($orderable_capacity)) {
                     continue;
                 }
+
                 $custom_asset_class = $definition->getAssetClassName();
                 if (
                     !in_array($custom_asset_class, $ORDER_TYPES, true)


### PR DESCRIPTION
## Summary

GLPI 11 introduced native custom assets defined via **Setup → Asset definitions**. The plugin's hardcoded `$ORDER_TYPES` array in `plugin_init_order()` does not include them, so custom asset classes never appear in the **Item type** dropdown when creating a new Product reference, making it impossible to order anything based on a custom asset definition.

This PR introduces a new **`Orderable` capacity** that admins enable per asset definition (Setup → Asset definitions → {asset} → Capacities). Asset classes whose definition has the capacity enabled — *and* for which the current user has read permission — are appended to `$ORDER_TYPES`.

## Implementation notes

* New `PluginOrderOrderableCapacity` class (extends `\Glpi\Asset\Capacity\AbstractCapacity`) with label, icon, description, and a usage count based on existing `PluginOrderReference` rows.
* Capacity is registered against `AssetDefinitionManager` at `plugin_init_order()` time, after which active definitions are iterated and filtered.
* Per-user permission is enforced via `$class::canView()`, which delegates to the asset's `AssignableItem` READ check plus the definition's `is_active` flag.
* The `class_exists()` guard on `\Glpi\Asset\AssetDefinitionManager` makes the block a no-op on GLPI ≤ 10.x, preserving backward compatibility.
* The existing `AssignableItem` handling from #560 already works correctly with custom asset classes once they are registered as orderable itemtypes — no changes to `link.class.php` are required.

## Testing

Tested on **GLPI 11.0.6, PHP 8.3, Order plugin 2.12.6** with a custom asset definition ("Електро Материали НН"):

| Step | Result |
| --- | --- |
| `Orderable` capacity appears in Capacities tab with proper label/icon/description | ✅ |
| Capacity disabled → custom asset absent from Product reference Item type dropdown | ✅ |
| Capacity enabled → custom asset appears, references can be created | ✅ |
| Type and Model dropdowns populate via `+ 'Type'` / `+ 'Model'` class name convention | ✅ |
| Order validation flow | ✅ |
| Item delivery flow | ✅ |
| Generate item massive action (form renders fully, submit works) | ✅ |
| Reception flow, generated assets appear in corresponding Assets section | ✅ |
| Native itemtypes (Computer, Monitor, Printer, Peripheral) verified unaffected | ✅ |

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.