### PR TITLE
Fix creation of dynamic property table deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+
+### Fixed
+
+- Fix warning : `creation of dynamic property $table is deprecated`
+
 ## [2.11.5] - 2026-03-24
 
 ### Fixed

--- a/inc/orderinjection.class.php
+++ b/inc/orderinjection.class.php
@@ -34,6 +34,8 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginOrderOrderInjection extends PluginOrderOrder implements PluginDatainjectionInjectionInterface
 {
+     protected $table;
+
     public function __construct()
     {
         $this->table = getTableForItemType(get_parent_class($this));

--- a/inc/reception.class.php
+++ b/inc/reception.class.php
@@ -1051,12 +1051,12 @@ JAVASCRIPT;
                                 $params2['POST']["delivery_number"],
                                 $params2['POST']["plugin_order_deliverystates_id"]
                             );
-                            if ($ma !== false) {
+                            if ($ma != false) {
                                  $ma->itemDone(__CLASS__, $key, MassiveAction::ACTION_OK);
                             }
                         } else {
                             Session::addMessageAfterRedirect(__("Item already taken delivery", "order"), true, ERROR);
-                            if ($ma !== false) {
+                            if ($ma != false) {
                                 $ma->itemDone(__CLASS__, $key, MassiveAction::ACTION_KO);
                             }
                         }

--- a/inc/referenceinjection.class.php
+++ b/inc/referenceinjection.class.php
@@ -34,6 +34,8 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginOrderReferenceInjection extends PluginOrderReference implements PluginDatainjectionInjectionInterface
 {
+    protected $table;
+
     public function __construct()
     {
         $this->table = getTableForItemType(get_parent_class($this));


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

Add a `protected $table` property to resolve the warning: 
>Creation of dynamic property PluginOrderOrderInjection::$table is deprecated in /home/samuel/TECLIB/DEV/GLPI/glpi10/plugins/order/inc/orderinjection.class.php at line 39

## Screenshots (if appropriate):
<img width="1415" height="49" alt="image" src="https://github.com/user-attachments/assets/feea6269-082d-4b2b-a298-29893c4ab2fc" />
