### PR TITLE
Add safety guards in Generate item flow for invalid references and non-existent classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix generate associated item massive action
+- Add safety guards in Generate item flow for invalid references and non-existent classes (GLPI 11 / PHP 8.3)
 - Update locales
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix generate associated item massive action
-- Add safety guards in Generate item flow for invalid references and non-existent classes (GLPI 11 / PHP 8.3)
+- Prevent invalid references and non-existent classes during generate item flow.
 - Update locales
 
 

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -148,7 +148,8 @@ class PluginOrderLink extends CommonDBChild
                     $row['template_name'] = "";
                 }
 
-                if (Toolbox::hasTrait($itemtype, AssignableItem::class)) {
+                // GLPI 11 safety: skip non-existent classes (e.g. uninstalled plugins like GenericObject)
+                if (class_exists($itemtype) && Toolbox::hasTrait($itemtype, AssignableItem::class)) {
                     $row['assignableitem'] = true;
                     if (!is_array($row['groups_id'])) {
                         $row['groups_id'] = $row['groups_id'] > 0 ? [$row['groups_id']] : [];
@@ -174,7 +175,7 @@ class PluginOrderLink extends CommonDBChild
             'active_entities' => $_SESSION['glpiactiveentities'] ?? [],
             'item_rows' => $item_rows,
             'order_web_dir' => $order_web_dir,
-            'assignableitem' => Toolbox::hasTrait($itemtype, AssignableItem::class),
+            'assignableitem' => class_exists($itemtype) && Toolbox::hasTrait($itemtype, AssignableItem::class),
         ]);
         return null;
     }

--- a/inc/reference.class.php
+++ b/inc/reference.class.php
@@ -471,14 +471,14 @@ class PluginOrderReference extends CommonDBTM
         } else {
             $row = $result->current();
             $item = getItemForItemtype($itemtype);
-            // GLPI 11 safety: custom asset classes may fail to resolve in HTTP context
-            // and templates_id may be 0 for entries created before plugin migration.
-            if ($item === false || empty($row["templates_id"])) {
+            if (
+                $item === false
+                || (int) $row["templates_id"] === 0
+                || !$item->getFromDB($row["templates_id"])
+            ) {
                 return 0;
             }
-            if (!$item->getFromDB($row["templates_id"])) {
-                return 0;
-            }
+
             if ($item->getField('entities_id') == $entity
             || ($item->maybeRecursive()
             && $item->fields['is_recursive']

--- a/inc/reference.class.php
+++ b/inc/reference.class.php
@@ -471,7 +471,14 @@ class PluginOrderReference extends CommonDBTM
         } else {
             $row = $result->current();
             $item = getItemForItemtype($itemtype);
-            $item->getFromDB($row["templates_id"]);
+            // GLPI 11 safety: custom asset classes may fail to resolve in HTTP context
+            // and templates_id may be 0 for entries created before plugin migration.
+            if ($item === false || empty($row["templates_id"])) {
+                return 0;
+            }
+            if (!$item->getFromDB($row["templates_id"])) {
+                return 0;
+            }
             if ($item->getField('entities_id') == $entity
             || ($item->maybeRecursive()
             && $item->fields['is_recursive']


### PR DESCRIPTION
## Summary

The Generate item massive action throws fatal errors on GLPI 11 / PHP 8.3 under two scenarios that have become common after the GLPI 10 → 11 migration:

1. **Invalid item references in `PluginOrderReference::getReferenceItemID()`** — `getItemForItemtype()` returns `false` in HTTP context for some dynamically-generated classes (notably `Glpi\CustomAsset\*` in GLPI 11), causing `Call to a member function getFromDB() on false`. Existing references migrated from older itemtypes may also have `templates_id = 0`, which makes `getFromDB()` fail silently and downstream `getField()` calls operate on a half-initialised object.

2. **Non-existent classes in `PluginOrderLink::generateItem()`** — `Toolbox::hasTrait()` internally calls `class_uses()`. On PHP 8.3 with the Safe library wrapper, `class_uses()` on a non-existent class throws `Safe\Exceptions\SplException` instead of emitting a warning. This is triggered by stale itemtype values in `glpi_plugin_order_orders_items` that reference classes from uninstalled plugins (e.g. `PluginGenericobjectOther` after migrating to native custom assets via the GenericObject 3.0.0 EOL migration tool).

## Implementation

Both call sites are now guarded:

- **`inc/reference.class.php`** — bail out early with `return 0` when the item cannot be instantiated or `templates_id` is empty.
- **`inc/link.class.php`** — prefix both `Toolbox::hasTrait()` calls with `class_exists()` so non-existent classes are skipped cleanly, both in the iteration loop (where `$row['assignableitem']` is set) and in the final `TemplateRenderer::display()` call.

The changes are defensive and minimal — they preserve all existing behaviour for valid native itemtypes, and only short-circuit when the underlying data cannot be resolved to a working class.

## Testing

Tested on GLPI 11.0.7, PHP 8.3, Order plugin 2.12.6:

| Scenario | Result |
|---|---|
| Order with valid native itemtypes (Computer, Monitor, etc.) — unchanged behaviour | ✅ |
| Order containing custom asset references (`Glpi\CustomAsset\otherAsset`) — form now renders fully and submits | ✅ |
| Order containing stale itemtypes from uninstalled plugins (`PluginGenericobjectOther`) — items skipped without fatal error, remaining items render | ✅ |
| Generate item massive action end-to-end (form → submit → items created) | ✅ |

Tested on a production instance with ~21,000 order line items and ~1,300 references, including a mix of native itemtypes, custom asset references, and stale references from a deinstalled plugin.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.