### PR TITLE
Fix incorrect declaration during order deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix generate associated item massive action
 - Update locales
-
+- Fix getDatabaseRelations() declarations to fix warnings on order deletion
 
 ## [2.12.6] - 2026-02-23
 

--- a/hook.php
+++ b/hook.php
@@ -162,62 +162,77 @@ function plugin_order_getDropdown()
 }
 
 
-/* define dropdown relations */
 function plugin_order_getDatabaseRelations()
 {
     $plugin = new Plugin();
     if ($plugin->isActivated("order")) {
+        // Ensure all plugin classes are declared so that getItemTypeForTable() resolves
+        // them with the correct case on the first call (before they are in the cache).
+        foreach (glob(PLUGIN_ORDER_DIR . '/inc/*.php') as $file) {
+            if (preg_match('/injection.class.php/', $file) === 0) {
+                include_once($file);
+            }
+        }
+
         return [
-            "glpi_plugin_order_orders" => [
-                "glpi_plugin_order_orderpayments" => "plugin_order_orders_id",
-                "glpi_plugin_order_ordertaxes" => "plugin_order_orders_id",
-                "glpi_plugin_order_ordertypes" => "plugin_order_orders_id",
-                "glpi_plugin_order_orderstates" => "plugin_order_orders_id",
-                "glpi_plugin_order_orders_items" => "plugin_order_orders_id",
-                "glpi_plugin_order_orders_suppliers" => "plugin_order_orders_id",
+            "glpi_plugin_order_orderpayments" => [
+                "glpi_plugin_order_orders" => "plugin_order_orderpayments_id"
+            ],
+            "glpi_plugin_order_ordertaxes" => [
+                "glpi_plugin_order_orders" => "plugin_order_ordertaxes_id"
+            ],
+            "glpi_plugin_order_ordertypes" => [
+                "glpi_plugin_order_orders" => "plugin_order_ordertypes_id"
+            ],
+            "glpi_plugin_order_orderstates" => [
+                "glpi_plugin_order_orders" => "plugin_order_orderstates_id"
             ],
             "glpi_plugin_order_accountsections" => [
-                "glpi_plugin_order_orders" => "plugin_order_accountsections_id",
+                "glpi_plugin_order_accountsections" => "plugin_order_accountsections_id"
             ],
             "glpi_plugin_order_analyticnatures" => [
-                "glpi_plugin_order_orders_items" => "plugin_order_analyticnatures_id",
+                "glpi_plugin_order_orders_items" => "plugin_order_analyticnatures_id"
             ],
             "glpi_plugin_order_deliverystates" => [
-                "glpi_plugin_order_orders_items" => "plugin_order_deliverystates_id",
+                "glpi_plugin_order_orders_items" => "plugin_order_deliverystates_id"
+            ],
+            "glpi_plugin_order_orders" => [
+                "glpi_plugin_order_orders_items"     => "plugin_order_orders_id",
+                "glpi_plugin_order_orders_suppliers" => "plugin_order_orders_id"
             ],
             "glpi_plugin_order_references" => [
-                "glpi_plugin_order_orders_items" => "plugin_order_references_id",
-                "glpi_plugin_order_references_suppliers" => "plugin_order_references_id",
+                "glpi_plugin_order_orders_items"         => "plugin_order_references_id",
+                "glpi_plugin_order_references_suppliers" => "plugin_order_references_id"
             ],
             "glpi_entities" => [
-                "glpi_plugin_order_orders" => "entities_id",
+                "glpi_plugin_order_orders"    => "entities_id",
                 "glpi_plugin_order_references" => "entities_id",
-                "glpi_plugin_order_others" => "entities_id",
-                "glpi_plugin_order_bills" => "entities_id",
+                "glpi_plugin_order_others"     => "entities_id",
+                "glpi_plugin_order_bills"      => "entities_id"
             ],
             "glpi_budgets" => [
-                "glpi_plugin_order_orders" => "budgets_id",
+                "glpi_plugin_order_orders" => "budgets_id"
             ],
             "glpi_plugin_order_othertypes" => [
-                "glpi_plugin_order_others" => "plugin_order_othertypes_id",
+                "glpi_plugin_order_others" => "plugin_order_othertypes_id"
             ],
             "glpi_suppliers" => [
-                "glpi_plugin_order_orders" => "suppliers_id",
-                "glpi_plugin_order_orders_suppliers" => "suppliers_id",
-                "glpi_plugin_order_references_suppliers" => "suppliers_id",
+                "glpi_plugin_order_orders"               => "suppliers_id",
+                "glpi_plugin_order_orders_suppliers"     => "suppliers_id",
+                "glpi_plugin_order_references_suppliers" => "suppliers_id"
             ],
             "glpi_manufacturers" => [
-                "glpi_plugin_order_references" => "manufacturers_id",
+                "glpi_plugin_order_references" => "manufacturers_id"
             ],
             "glpi_contacts" => [
-                "glpi_plugin_order_orders" => "contacts_id",
+                "glpi_plugin_order_orders" => "contacts_id"
             ],
             "glpi_locations" => [
-                "glpi_plugin_order_orders" => "locations_id",
+                "glpi_plugin_order_orders" => "locations_id"
             ],
             "glpi_profiles" => [
-                "glpi_plugin_order_profiles" => "profiles_id",
-            ],
+                "glpi_plugin_order_profiles" => "profiles_id"
+            ]
         ];
     } else {
         return [];

--- a/hook.php
+++ b/hook.php
@@ -176,63 +176,63 @@ function plugin_order_getDatabaseRelations()
 
         return [
             "glpi_plugin_order_orderpayments" => [
-                "glpi_plugin_order_orders" => "plugin_order_orderpayments_id"
+                "glpi_plugin_order_orders" => "plugin_order_orderpayments_id",
             ],
             "glpi_plugin_order_ordertaxes" => [
-                "glpi_plugin_order_orders" => "plugin_order_ordertaxes_id"
+                "glpi_plugin_order_orders" => "plugin_order_ordertaxes_id",
             ],
             "glpi_plugin_order_ordertypes" => [
-                "glpi_plugin_order_orders" => "plugin_order_ordertypes_id"
+                "glpi_plugin_order_orders" => "plugin_order_ordertypes_id",
             ],
             "glpi_plugin_order_orderstates" => [
-                "glpi_plugin_order_orders" => "plugin_order_orderstates_id"
+                "glpi_plugin_order_orders" => "plugin_order_orderstates_id",
             ],
             "glpi_plugin_order_accountsections" => [
-                "glpi_plugin_order_accountsections" => "plugin_order_accountsections_id"
+                "glpi_plugin_order_accountsections" => "plugin_order_accountsections_id",
             ],
             "glpi_plugin_order_analyticnatures" => [
-                "glpi_plugin_order_orders_items" => "plugin_order_analyticnatures_id"
+                "glpi_plugin_order_orders_items" => "plugin_order_analyticnatures_id",
             ],
             "glpi_plugin_order_deliverystates" => [
-                "glpi_plugin_order_orders_items" => "plugin_order_deliverystates_id"
+                "glpi_plugin_order_orders_items" => "plugin_order_deliverystates_id",
             ],
             "glpi_plugin_order_orders" => [
                 "glpi_plugin_order_orders_items"     => "plugin_order_orders_id",
-                "glpi_plugin_order_orders_suppliers" => "plugin_order_orders_id"
+                "glpi_plugin_order_orders_suppliers" => "plugin_order_orders_id",
             ],
             "glpi_plugin_order_references" => [
                 "glpi_plugin_order_orders_items"         => "plugin_order_references_id",
-                "glpi_plugin_order_references_suppliers" => "plugin_order_references_id"
+                "glpi_plugin_order_references_suppliers" => "plugin_order_references_id",
             ],
             "glpi_entities" => [
                 "glpi_plugin_order_orders"    => "entities_id",
                 "glpi_plugin_order_references" => "entities_id",
                 "glpi_plugin_order_others"     => "entities_id",
-                "glpi_plugin_order_bills"      => "entities_id"
+                "glpi_plugin_order_bills"      => "entities_id",
             ],
             "glpi_budgets" => [
-                "glpi_plugin_order_orders" => "budgets_id"
+                "glpi_plugin_order_orders" => "budgets_id",
             ],
             "glpi_plugin_order_othertypes" => [
-                "glpi_plugin_order_others" => "plugin_order_othertypes_id"
+                "glpi_plugin_order_others" => "plugin_order_othertypes_id",
             ],
             "glpi_suppliers" => [
                 "glpi_plugin_order_orders"               => "suppliers_id",
                 "glpi_plugin_order_orders_suppliers"     => "suppliers_id",
-                "glpi_plugin_order_references_suppliers" => "suppliers_id"
+                "glpi_plugin_order_references_suppliers" => "suppliers_id",
             ],
             "glpi_manufacturers" => [
-                "glpi_plugin_order_references" => "manufacturers_id"
+                "glpi_plugin_order_references" => "manufacturers_id",
             ],
             "glpi_contacts" => [
-                "glpi_plugin_order_orders" => "contacts_id"
+                "glpi_plugin_order_orders" => "contacts_id",
             ],
             "glpi_locations" => [
-                "glpi_plugin_order_orders" => "locations_id"
+                "glpi_plugin_order_orders" => "locations_id",
             ],
             "glpi_profiles" => [
-                "glpi_plugin_order_profiles" => "profiles_id"
-            ]
+                "glpi_plugin_order_profiles" => "profiles_id",
+            ],
         ];
     } else {
         return [];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #576

When deleting an order, GLPI was logging the following warnings:

```text
Invalid relations declared between "glpi_plugin_order_orderpayments" and
"glpi_plugin_order_orders" table. Target field "plugin_order_orderpayments_id"
is not a foreign key field of "PluginOrderOrderpayment".
```

Three separate issues were identified:

### 1. Incorrect Parent/Child Relationship Direction

The previous relation declarations incorrectly defined `glpi_plugin_order_orders` as the parent table and the dropdown tables (`orderpayments`, `ordertaxes`, `ordertypes`, `orderstates`) as child tables.

Additionally, the relations referenced a non-existent field (`plugin_order_orders_id`) in these dropdown tables.

The correct relationship direction is the opposite:

* Dropdown tables are the parent entities.
* `glpi_plugin_order_orders` is the child table through foreign keys such as:

  * `plugin_order_orderpayments_id`
  * `plugin_order_ordertaxes_id`
  * `plugin_order_ordertypes_id`
  * `plugin_order_orderstates_id`

---

### 2. Case Mismatch During Initial Class Resolution

GLPI core method `getItemTypeForTable()` returns a lowercase-computed class name (`PluginOrderOrderpayment`) during the first resolution, then returns the correctly cached class name (`PluginOrderOrderPayment`) on subsequent calls.

Inside `getDbRelations()`, GLPI validates these values using a strict comparison (`!==`), which causes the validation to fail if the plugin classes have not yet been loaded at the time the method is executed.

As a result, relation validation failed during the initial lookup phase.

---

### 3. Missing `glpi_` Table Prefix

The `analyticnatures` table was incorrectly declared as:

```text
plugin_order_analyticnatures
```

instead of the correct table name:

```text
glpi_plugin_order_analyticnatures
```

---

## Solution

The issue was resolved through the following changes:

* Refactored `plugin_order_getDatabaseRelations()` to declare all relations using the correct parent → child direction.
* Added `include_once` statements for all `inc/*.php` files at the beginning of the function to ensure that all plugin classes are loaded before GLPI attempts class resolution, preventing case mismatch issues.
* Corrected the table declaration:

  * `plugin_order_analyticnatures`
  * → `glpi_plugin_order_analyticnatures`

