### PR TITLE
fix(uninstall): Table not removed on uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix generate associated item massive action
 - Prevent invalid references and non-existent classes during generate item flow.
 - Update locales
+- Fix `glpi_plugin_order_referencefrees` table not removed on uninstall
 
 
 ## [2.12.6] - 2026-02-23

--- a/hook.php
+++ b/hook.php
@@ -128,7 +128,8 @@ function plugin_order_uninstall()
         'PluginOrderOrdertype', 'PluginOrderOther', 'PluginOrderOthertype',
         'PluginOrderPreference', 'PluginOrderProfile', 'PluginOrderReference_Supplier',
         'PluginOrderSurveySupplier', 'PluginOrderDocumentCategory',
-        'PluginOrderAccountsection', 'PluginOrderAnalyticnature',
+        'PluginOrderReferenceFree', 'PluginOrderAccountsection',
+        'PluginOrderAnalyticnature',
     ];
     foreach ($classes as $class) {
         call_user_func([$class, 'uninstall']);


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44278
- Here is a brief description of what this PR does
Fix `glpi_plugin_order_referencefrees` table not removed on uninstall

## Screenshots (if appropriate):
<img width="858" height="257" alt="image" src="https://github.com/user-attachments/assets/4675b569-f0c1-4d77-879b-3a98bc61ae92" />

