### PR TITLE
fix(install): Remove unnecessary message during plugin installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix generate associated item massive action
 - Prevent invalid references and non-existent classes during generate item flow.
+- Remove unnecessary message during plugin installation
 - Update locales
 
 

--- a/hook.php
+++ b/hook.php
@@ -47,13 +47,6 @@ function plugin_order_install()
         }
     }
 
-    echo "<center>";
-    echo "<table class='tab_cadre_fixe'>";
-    echo "<tr><th>" . __s("Plugin installation or upgrade", "order") . "<th></tr>";
-
-    echo "<tr class='tab_bg_1'>";
-    echo "<td align='center'>";
-
     $migration = new Migration(PLUGIN_ORDER_VERSION);
     $classes = ['PluginOrderConfig', 'PluginOrderBillState', 'PluginOrderBillType',
         'PluginOrderOrderState', 'PluginOrderOrder','PluginOrderOrder_Item',
@@ -77,11 +70,6 @@ function plugin_order_install()
             }
         }
     }
-
-    echo "</td>";
-    echo "</tr>";
-    echo "</table>";
-    echo "</center>";
 
     //Create directories for the plugin's files
     $directories = [PLUGIN_ORDER_TEMPLATE_DIR        => 'templates',


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44277
- Here is a brief description of what this PR does
When installing the plugin via the CLI, an HTML message appears that makes the logs difficult to read

## Screenshots (if appropriate):
<img width="1666" height="80" alt="image" src="https://github.com/user-attachments/assets/b08cdca1-68b6-4e00-a909-6fd885a9c6d4" />

