### PR TITLE
2.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.12.7] - 2026-06-03
+## [2.12.8] - 2026-06-24
 
 ### Added
 - Add an `Orderable` capacity for GLPI 11 custom asset definitions.
+
+
+## [2.12.7] - 2026-06-03
 
 ### Fixed
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,6 +30,11 @@
    </authors>
    <versions>
       <version>
+          <num>2.12.8</num>
+          <compatibility>~11.0.0</compatibility>
+          <download_url>https://github.com/pluginsGLPI/order/releases/download/2.12.8/glpi-order-2.12.8.tar.bz2</download_url>
+      </version>
+      <version>
           <num>2.12.7</num>
           <compatibility>~11.0.0</compatibility>
           <download_url>https://github.com/pluginsGLPI/order/releases/download/2.12.7/glpi-order-2.12.7.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -32,7 +32,7 @@ use Glpi\Asset\AssetDefinitionManager;
 
 use function Safe\define;
 
-define('PLUGIN_ORDER_VERSION', '2.12.7');
+define('PLUGIN_ORDER_VERSION', '2.12.8');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ORDER_MIN_GLPI", "11.0.0");


### PR DESCRIPTION
## [2.12.8] - 2026-06-24

### Added
- Add an `Orderable` capacity for GLPI 11 custom asset definitions.