### PR TITLE
Add/consumable mass action link associated items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Added
+- Add grouped actions to link consumables and related items
+
 ## [2.12.8] - 2026-06-24
 
 ### Added

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -636,10 +636,9 @@ class PluginOrderLink extends CommonDBChild
                 //  For consumables and cartridges, createLinkWithItem creates a new item
                 // (glpi_consumables/glpi_cartridges) for each selected detail line;
                 // therefore, multiple items can be linked to the same reference item at once
-                $reference = new PluginOrderReference();
-                $reference->getFromDB($ma->POST["plugin_order_references_id"]);
-                $allow_multiple_link = in_array(
-                    $reference->fields["itemtype"] ?? '',
+                $first_item_data = reset($ma->POST['add_items']);
+                $allow_multiple_link = is_array($first_item_data) && in_array(
+                    $first_item_data['itemtype'] ?? '',
                     ['ConsumableItem', 'CartridgeItem'],
                     true,
                 );

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -633,7 +633,18 @@ class PluginOrderLink extends CommonDBChild
                 break;
 
             case 'createLink':
-                if (count($ids) > 1) {
+                //  For consumables and cartridges, createLinkWithItem creates a new item
+                // (glpi_consumables/glpi_cartridges) for each selected detail line;
+                // therefore, multiple items can be linked to the same reference item at once
+                $reference = new PluginOrderReference();
+                $reference->getFromDB($ma->POST["plugin_order_references_id"]);
+                $allow_multiple_link = in_array(
+                    $reference->fields["itemtype"] ?? '',
+                    ['ConsumableItem', 'CartridgeItem'],
+                    true,
+                );
+
+                if (!$allow_multiple_link && count($ids) > 1) {
                     $ma->addMessage(__s("Cannot link several items to one detail line", "order"));
                     foreach ($ids as $id) {
                         $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -636,10 +636,13 @@ class PluginOrderLink extends CommonDBChild
                 //  For consumables and cartridges, createLinkWithItem creates a new item
                 // (glpi_consumables/glpi_cartridges) for each selected detail line;
                 // therefore, multiple items can be linked to the same reference item at once
-                $first_item_data = reset($ma->POST['add_items']);
-                $allow_multiple_link = is_array($first_item_data) && in_array(
-                    $first_item_data['itemtype'] ?? '',
-                    ['ConsumableItem', 'CartridgeItem'],
+                $allow_multiple_link = !empty($ma->POST['add_items']) && array_reduce(
+                    $ma->POST['add_items'],
+                    fn($carry, $data) => $carry && in_array(
+                        $data['itemtype'] ?? '',
+                        ['ConsumableItem', 'CartridgeItem'],
+                        true,
+                    ),
                     true,
                 );
 

--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -636,7 +636,7 @@ class PluginOrderLink extends CommonDBChild
                 //  For consumables and cartridges, createLinkWithItem creates a new item
                 // (glpi_consumables/glpi_cartridges) for each selected detail line;
                 // therefore, multiple items can be linked to the same reference item at once
-                $allow_multiple_link = !empty($ma->POST['add_items']) && array_reduce(
+                $allow_multiple_link = isset($ma->POST['add_items']) && $ma->POST['add_items'] !== [] && array_reduce(
                     $ma->POST['add_items'],
                     fn($carry, $data) => $carry && in_array(
                         $data['itemtype'] ?? '',

--- a/inc/order.class.php
+++ b/inc/order.class.php
@@ -1825,7 +1825,6 @@ class PluginOrderOrder extends CommonDBTM
             $this->getFromDB($ID);
 
             if (file_exists(PLUGIN_ORDER_TEMPLATE_CUSTOM_DIR . "custom.php")) {
-                // @phpstan-ignore-next-line: custom.php is not a file or it does not exist.
                 include_once(PLUGIN_ORDER_TEMPLATE_CUSTOM_DIR . "custom.php");
             }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45040
- Add grouped actions to link consumables and related items : For consumables and cartridges, createLinkWithItem creates a new item (glpi_consumables/glpi_cartridges) for each selected detail line; therefore, multiple items can be linked to the same reference item at once

## Screenshots (if appropriate):
