### PR TITLE
2.12.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+## [2.12.10] - 2026-09-11
 
 ### Fixed
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,6 +30,16 @@
    </authors>
    <versions>
       <version>
+         <num>2.12.10</num>
+         <compatibility>~11.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/order/releases/download/2.12.10/glpi-order-2.12.10.tar.bz2</download_url>
+      </version>
+      <version>
+          <num>2.11.6</num>
+          <compatibility>~10.0.11</compatibility>
+          <download_url>https://github.com/pluginsGLPI/order/releases/download/2.11.6/glpi-order-2.11.6.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.12.9</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/order/releases/download/2.12.9/glpi-order-2.12.9.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -32,7 +32,7 @@ use Glpi\Asset\AssetDefinitionManager;
 
 use function Safe\define;
 
-define('PLUGIN_ORDER_VERSION', '2.12.9');
+define('PLUGIN_ORDER_VERSION', '2.12.10');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ORDER_MIN_GLPI", "11.0.0");


### PR DESCRIPTION
## [2.12.10] - 2026-09-11

### Fixed

- Fix `Take item delivery` and `Cancel reception` action for `Software License`
- Fix missing rights checks
- Fix unescaped output in order/reception forms
- Fix fatal error on profile deletion caused by a stale `glpi_plugin_order_profiles` relation declaration
- Fix SQL error during item generation when the reference's template has financial information